### PR TITLE
Dismissable signal overlay with inline vault card

### DIFF
--- a/src/components/simulation/Simulation.astro
+++ b/src/components/simulation/Simulation.astro
@@ -559,6 +559,31 @@
     display: flex;
   }
 
+  .signal-overlay__close {
+    position: absolute;
+    top: var(--space-sm);
+    right: var(--space-sm);
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    padding: var(--space-xs) var(--space-sm);
+    cursor: pointer;
+    z-index: 1;
+    transition: color var(--duration-fast) var(--ease-out),
+                border-color var(--duration-fast) var(--ease-out);
+  }
+
+  .signal-overlay__close:hover {
+    color: var(--color-text);
+    border-color: var(--color-accent-dim);
+  }
+
+  .vault-card--signal {
+    border-color: var(--color-accent-dim);
+  }
+
   .signal-block {
     position: absolute;
   }

--- a/src/components/simulation/renderer.ts
+++ b/src/components/simulation/renderer.ts
@@ -403,13 +403,55 @@ export class SimulationRenderer {
       tl.scrollTop = tl.scrollHeight;
     }
 
+    // Add signal as a vault card in the step sequence (visible when overlay is dismissed)
+    const card = document.createElement('div');
+    card.className = 'vault-card vault-card--signal vault-card--expanded';
+    card.setAttribute('data-step', 'step-7');
+
+    const cardHeader = document.createElement('div');
+    cardHeader.className = 'vault-card__header';
+    cardHeader.addEventListener('click', () => card.classList.toggle('vault-card--expanded'));
+
+    const stepTag = document.createElement('span');
+    stepTag.className = 'vault-card__step-tag';
+    stepTag.textContent = 'Step 7';
+
+    const cardTitle = document.createElement('span');
+    cardTitle.className = 'vault-card__title';
+    cardTitle.textContent = 'Output Signal';
+
+    const chevron = document.createElement('span');
+    chevron.className = 'vault-card__chevron';
+    chevron.textContent = '\u25b8';
+
+    cardHeader.append(stepTag, cardTitle, chevron);
+    card.appendChild(cardHeader);
+
+    const cardBody = document.createElement('div');
+    cardBody.className = 'vault-card__body';
+    const cardPre = document.createElement('pre');
+    cardPre.className = 'signal-block__json';
+    cardPre.textContent = json;
+    cardBody.appendChild(cardPre);
+    card.appendChild(cardBody);
+
+    this.els.vaultEvents.appendChild(card);
+
+    // Signal overlay — dramatic reveal, dismissable
     const overlay = this.els.signalOverlay;
-    // Clear previous content safely
     while (overlay.firstChild) {
       overlay.removeChild(overlay.firstChild);
     }
 
-    // Centre signal block
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'signal-overlay__close';
+    closeBtn.setAttribute('aria-label', 'Close signal overlay');
+    closeBtn.textContent = '\u2715';
+    closeBtn.addEventListener('click', () => {
+      overlay.classList.remove('signal-overlay--visible');
+    });
+    overlay.appendChild(closeBtn);
+
     const centre = document.createElement('div');
     centre.className = 'signal-block signal-block--centre';
 


### PR DESCRIPTION
## Summary

- Step 7 signal overlay now has a close button (x) in the top-right corner
- Dismissing the overlay reveals the vault panel with all protocol steps scrollable and expandable
- A new Step 7 Output Signal card is added to the step sequence (auto-expanded, collapsible like other cards)
- Replay resets everything cleanly

## Test plan

- [ ] Signal overlay appears at Step 7 with close button visible
- [ ] Click close: overlay hides, vault panel shows all steps including Step 7 signal card
- [ ] Step 7 card is expandable/collapsible like other vault cards
- [ ] Replay works: overlay reappears fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)