### PR TITLE
fix: mobile timeline chat messages and layout shift

### DIFF
--- a/src/components/simulation/Simulation.astro
+++ b/src/components/simulation/Simulation.astro
@@ -665,7 +665,8 @@
       display: flex;
       flex-direction: column;
       gap: var(--space-sm);
-      max-height: calc(100vh - 120px);
+      height: calc(100vh - 120px);
+      min-height: 300px;
       overflow-y: auto;
       scroll-behavior: smooth;
       padding: var(--space-md);

--- a/src/components/simulation/renderer.ts
+++ b/src/components/simulation/renderer.ts
@@ -114,7 +114,7 @@ export class SimulationRenderer {
     container.scrollTop = container.scrollHeight;
 
     // Timeline: show "typing..." placeholder on first character
-    if (charIndex === 0 && this.els.timeline && !this.timelineBubbles.has(key)) {
+    if (this.els.timeline && !this.timelineBubbles.has(key)) {
       this.timelineBubbles.add(key);
       this._appendTimelineChat(msg, true);
     }


### PR DESCRIPTION
## Summary
- Remove `charIndex === 0` guard in `renderer.ts` that prevented timeline chat bubbles from appearing (word-by-word typing starts at non-zero index)
- Change `.sim-timeline` from `max-height` to fixed `height` + `min-height` to eliminate layout shift on mobile

## Test plan
- [ ] Mobile (DevTools 390x844): chat messages appear with fade-in as simulation plays
- [ ] Timeline container is stable height from the start — no layout shift
- [ ] All phases show their chat messages between separators
- [ ] Desktop: no regression (timeline is `display: none`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)