### PR TITLE
feat: desktop layout coherence, mobile protocol cards, per-principal colours

### DIFF
--- a/src/components/sections/LinksResources.astro
+++ b/src/components/sections/LinksResources.astro
@@ -44,6 +44,7 @@
 <style>
   h2 {
     margin-bottom: var(--space-2xl);
+    text-align: center;
   }
 
   .resource-list {
@@ -51,7 +52,8 @@
     display: flex;
     flex-direction: column;
     gap: 0;
-    max-width: 600px;
+    max-width: var(--content-max);
+    margin: 0 auto;
     border: 1px solid var(--color-border);
     border-radius: 6px;
     overflow: hidden;

--- a/src/components/sections/PositioningText.astro
+++ b/src/components/sections/PositioningText.astro
@@ -22,7 +22,8 @@
 
 <style>
   .positioning {
-    max-width: 640px;
+    max-width: var(--content-max);
+    margin: 0 auto;
   }
 
   .positioning p {

--- a/src/components/sections/ProtocolOverview.astro
+++ b/src/components/sections/ProtocolOverview.astro
@@ -95,11 +95,13 @@
 <style>
   h2 {
     margin-bottom: var(--space-md);
+    text-align: center;
   }
 
   .intro {
-    max-width: 580px;
-    margin-bottom: var(--space-2xl);
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-2xl);
+    text-align: center;
   }
 
   .steps {
@@ -107,7 +109,8 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-lg);
-    max-width: 780px;
+    max-width: var(--content-max);
+    margin: 0 auto;
   }
 
   .step {

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -67,11 +67,13 @@
 <style>
   h2 {
     margin-bottom: var(--space-md);
+    text-align: center;
   }
 
   .intro {
-    max-width: 640px;
-    margin-bottom: var(--space-2xl);
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-2xl);
+    text-align: center;
   }
 
   .cards {
@@ -178,6 +180,8 @@
 
   .disambiguation {
     font-size: var(--text-sm);
-    max-width: none;
+    max-width: var(--content-max);
+    margin: 0 auto;
+    text-align: center;
   }
 </style>

--- a/src/components/sections/WhyThisMatters.astro
+++ b/src/components/sections/WhyThisMatters.astro
@@ -28,10 +28,12 @@
 <style>
   h2 {
     margin-bottom: var(--space-md);
+    text-align: center;
   }
 
   .content {
-    max-width: 680px;
+    max-width: var(--content-max);
+    margin: 0 auto;
     display: flex;
     flex-direction: column;
     gap: var(--space-md);

--- a/src/components/simulation/Simulation.astro
+++ b/src/components/simulation/Simulation.astro
@@ -322,15 +322,41 @@
   }
 
   .chat-bubble--user {
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid var(--color-border-subtle);
     border-bottom-right-radius: 3px;
   }
 
   .chat-bubble--bot {
-    background: rgba(90, 180, 192, 0.05);
-    border: 1px solid rgba(90, 180, 192, 0.12);
     border-bottom-left-radius: 3px;
+  }
+
+  /* Per-principal bubble colours — desktop panels */
+  .chat-message[data-principal="alice"] .chat-bubble--user {
+    background: var(--color-alice-bg);
+    border: 1px solid var(--color-alice-border);
+  }
+
+  .chat-message[data-principal="alice"] .chat-bubble--bot {
+    background: hsla(210, 50%, 65%, 0.04);
+    border: 1px solid hsla(210, 35%, 48%, 0.15);
+  }
+
+  .chat-message[data-principal="bob"] .chat-bubble--user {
+    background: var(--color-bob-bg);
+    border: 1px solid var(--color-bob-border);
+  }
+
+  .chat-message[data-principal="bob"] .chat-bubble--bot {
+    background: hsla(35, 55%, 65%, 0.04);
+    border: 1px solid hsla(35, 40%, 48%, 0.15);
+  }
+
+  /* Principal-based name colours — desktop */
+  .chat-message[data-principal="alice"] .chat-message__name {
+    color: var(--color-alice);
+  }
+
+  .chat-message[data-principal="bob"] .chat-message__name {
+    color: var(--color-bob);
   }
 
   /* Typing cursor */
@@ -694,27 +720,39 @@
       margin-top: 0;
     }
 
+    /* Prevent flex items from shrinking — timeline scrolls, don't collapse */
+    .tl-phase-separator,
+    .tl-chat,
+    .tl-card,
+    .tl-signal {
+      flex-shrink: 0;
+    }
+
     /* ── Timeline chat bubbles ── */
     .tl-chat {
       display: flex;
       flex-direction: column;
       gap: 2px;
-      max-width: 85%;
+      max-width: 78%;
     }
 
-    .tl-chat--left {
-      align-self: flex-start;
-    }
-
-    .tl-chat--right {
+    /* Humans right, bots left */
+    .tl-chat--user {
       align-self: flex-end;
+    }
+
+    .tl-chat--bot {
+      align-self: flex-start;
     }
 
     .tl-chat__name {
       font-size: var(--text-xs);
-      color: var(--color-text-dim);
       padding: 0 var(--space-sm);
     }
+
+    /* Principal-based name colours */
+    .tl-chat[data-principal="alice"] .tl-chat__name { color: var(--color-alice); }
+    .tl-chat[data-principal="bob"] .tl-chat__name { color: var(--color-bob); }
 
     .tl-chat__text {
       padding: var(--space-sm) var(--space-md);
@@ -726,15 +764,31 @@
       white-space: pre-wrap;
     }
 
-    .tl-chat--user .tl-chat__text {
-      background: rgba(255, 255, 255, 0.03);
-      border: 1px solid var(--color-border-subtle);
+    /* Alice human — lighter blue */
+    .tl-chat--user[data-principal="alice"] .tl-chat__text {
+      background: var(--color-alice-bg);
+      border: 1px solid var(--color-alice-border);
       border-bottom-right-radius: 3px;
     }
 
-    .tl-chat--bot .tl-chat__text {
-      background: rgba(90, 180, 192, 0.05);
-      border: 1px solid rgba(90, 180, 192, 0.12);
+    /* AliceBot — darker blue */
+    .tl-chat--bot[data-principal="alice"] .tl-chat__text {
+      background: hsla(210, 50%, 65%, 0.04);
+      border: 1px solid hsla(210, 35%, 48%, 0.15);
+      border-bottom-left-radius: 3px;
+    }
+
+    /* Bob human — lighter warm */
+    .tl-chat--user[data-principal="bob"] .tl-chat__text {
+      background: var(--color-bob-bg);
+      border: 1px solid var(--color-bob-border);
+      border-bottom-right-radius: 3px;
+    }
+
+    /* BobBot — darker warm */
+    .tl-chat--bot[data-principal="bob"] .tl-chat__text {
+      background: hsla(35, 55%, 65%, 0.04);
+      border: 1px solid hsla(35, 40%, 48%, 0.15);
       border-bottom-left-radius: 3px;
     }
 
@@ -779,10 +833,11 @@
       display: flex;
       align-items: center;
       gap: var(--space-sm);
-      padding: var(--space-xs) var(--space-sm);
+      padding: var(--space-sm) var(--space-md);
       background: rgba(26, 40, 72, 0.2);
       cursor: pointer;
       user-select: none;
+      min-height: 40px;
     }
 
     .tl-card__tag {

--- a/src/components/simulation/renderer.ts
+++ b/src/components/simulation/renderer.ts
@@ -142,7 +142,8 @@ export class SimulationRenderer {
     const tl = this.els.timeline!;
     const key = this._bubbleKey(msg);
     const el = document.createElement('div');
-    el.className = `tl-chat tl-chat--${msg.panel} tl-chat--${msg.sender}`;
+    el.className = `tl-chat tl-chat--${msg.sender}`;
+    el.dataset.principal = msg.panel === 'left' ? 'alice' : 'bob';
     el.setAttribute('data-tl-key', key);
 
     const name = document.createElement('span');
@@ -172,6 +173,7 @@ export class SimulationRenderer {
   private _createBubble(msg: ChatMessage): HTMLElement {
     const wrap = document.createElement('div');
     wrap.className = `chat-message chat-message--${msg.sender}`;
+    wrap.dataset.principal = msg.panel === 'left' ? 'alice' : 'bob';
 
     const name = document.createElement('span');
     name.className = 'chat-message__name';

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -55,8 +55,19 @@
   --space-3xl: 4rem;
   --space-4xl: 5rem;
 
+  /* Principal colours — per-agent colour coding */
+  --color-alice: hsl(210, 50%, 68%);
+  --color-alice-dim: hsl(210, 35%, 48%);
+  --color-alice-bg: hsla(210, 50%, 65%, 0.07);
+  --color-alice-border: hsla(210, 50%, 65%, 0.18);
+  --color-bob: hsl(35, 55%, 68%);
+  --color-bob-dim: hsl(35, 40%, 48%);
+  --color-bob-bg: hsla(35, 55%, 65%, 0.07);
+  --color-bob-border: hsla(35, 55%, 65%, 0.18);
+
   /* Layout */
   --container-max: 1400px;
+  --content-max: 760px;
   --container-padding: 2rem;
   --simulation-height: 600px;
 


### PR DESCRIPTION
## Summary
- Center all prose sections on desktop with consistent `--content-max: 760px` width and centered headings
- Fix mobile protocol cards rendering as thin bars (`flex-shrink: 0` prevents flex collapsing of `overflow:hidden` cards)
- Chat bubble positioning: humans always right, bots always left on mobile timeline
- Per-principal colour coding: Alice/AliceBot in blue, Bob/BobBot in amber (desktop + mobile)

## Test plan
- [ ] Desktop 1440px: all prose sections centered, cards full-width, headings centered
- [ ] Mobile 390x844: protocol cards render as readable, tappable cards with expand/collapse
- [ ] Mobile: humans on right, bots on left in timeline
- [ ] Both: Alice-family blue, Bob-family amber colour coding visible
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)