### PR TITLE
Left-align all text sections for readability

### DIFF
--- a/src/components/sections/LinksResources.astro
+++ b/src/components/sections/LinksResources.astro
@@ -44,7 +44,6 @@
 <style>
   h2 {
     margin-bottom: var(--space-2xl);
-    text-align: center;
   }
 
   .resource-list {

--- a/src/components/sections/ProtocolOverview.astro
+++ b/src/components/sections/ProtocolOverview.astro
@@ -95,13 +95,11 @@
 <style>
   h2 {
     margin-bottom: var(--space-md);
-    text-align: center;
   }
 
   .intro {
     max-width: var(--content-max);
     margin: 0 auto var(--space-2xl);
-    text-align: center;
   }
 
   .steps {

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -67,13 +67,11 @@
 <style>
   h2 {
     margin-bottom: var(--space-md);
-    text-align: center;
   }
 
   .intro {
     max-width: var(--content-max);
     margin: 0 auto var(--space-2xl);
-    text-align: center;
   }
 
   .cards {
@@ -182,6 +180,5 @@
     font-size: var(--text-sm);
     max-width: var(--content-max);
     margin: 0 auto;
-    text-align: center;
   }
 </style>

--- a/src/components/sections/WhyThisMatters.astro
+++ b/src/components/sections/WhyThisMatters.astro
@@ -28,7 +28,6 @@
 <style>
   h2 {
     margin-bottom: var(--space-md);
-    text-align: center;
   }
 
   .content {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,8 +95,11 @@ import LinksResources from '../components/sections/LinksResources.astro';
 <style>
   .hero {
     padding: var(--space-3xl) 0 var(--space-2xl);
-    text-align: center;
     border-bottom: 1px solid var(--color-border-subtle);
+  }
+
+  .hero > .container {
+    max-width: var(--content-max);
   }
 
   .hero__title {
@@ -125,8 +128,7 @@ import LinksResources from '../components/sections/LinksResources.astro';
   .hero__guarantees {
     list-style: none;
     max-width: fit-content;
-    margin: var(--space-lg) auto 0;
-    text-align: left;
+    margin-top: var(--space-lg);
     display: flex;
     flex-direction: column;
     gap: var(--space-xs);
@@ -149,7 +151,6 @@ import LinksResources from '../components/sections/LinksResources.astro';
   .hero__ctas {
     display: flex;
     gap: var(--space-md);
-    justify-content: center;
     margin-top: var(--space-xl);
   }
 


### PR DESCRIPTION
## Summary
- Remove `text-align: center` from all prose sections (hero, protocol, vault family, why this matters, links)
- Constrain hero content to `--content-max` (760px) for consistency with other sections
- Left-align CTAs and guarantee list in hero
- Simulation section header stays centered (intentional)

## Test plan
- [ ] Desktop 1440px: all text left-aligned within centered containers
- [ ] Text blocks have consistent max-width across sections
- [ ] Simulation section header remains centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)