### PR TITLE
Left-align sim header, constrain section headings

### DIFF
--- a/src/components/sections/LinksResources.astro
+++ b/src/components/sections/LinksResources.astro
@@ -43,7 +43,8 @@
 
 <style>
   h2 {
-    margin-bottom: var(--space-2xl);
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-2xl);
   }
 
   .resource-list {

--- a/src/components/sections/ProtocolOverview.astro
+++ b/src/components/sections/ProtocolOverview.astro
@@ -94,7 +94,8 @@
 
 <style>
   h2 {
-    margin-bottom: var(--space-md);
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-md);
   }
 
   .intro {

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -66,7 +66,8 @@
 
 <style>
   h2 {
-    margin-bottom: var(--space-md);
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-md);
   }
 
   .intro {

--- a/src/components/sections/WhyThisMatters.astro
+++ b/src/components/sections/WhyThisMatters.astro
@@ -27,7 +27,8 @@
 
 <style>
   h2 {
-    margin-bottom: var(--space-md);
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-md);
   }
 
   .content {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -194,10 +194,9 @@ import LinksResources from '../components/sections/LinksResources.astro';
   .sim-module-header {
     display: flex;
     flex-direction: column;
-    align-items: center;
     gap: var(--space-lg);
-    margin-bottom: var(--space-lg);
-    text-align: center;
+    max-width: var(--content-max);
+    margin: 0 auto var(--space-lg);
   }
 
   .sim-module-header__title {
@@ -209,7 +208,6 @@ import LinksResources from '../components/sections/LinksResources.astro';
 
   .sim-module-header__subtitle {
     font-size: var(--text-sm);
-    max-width: var(--content-max);
     line-height: var(--leading-relaxed);
   }
 
@@ -298,7 +296,8 @@ import LinksResources from '../components/sections/LinksResources.astro';
     color: var(--color-text-dim);
     letter-spacing: 0.02em;
     margin-top: var(--space-sm);
-    text-align: center;
+    max-width: var(--content-max);
+    margin: var(--space-sm) auto 0;
   }
 
   @media (max-width: 1023px) {


### PR DESCRIPTION
## Summary
- Left-align "Mediation Triage Demo" header, subtitle, controls, and legend within `--content-max`
- Constrain all section `h2` headings (Protocol, The Vault Family, Why This Matters, Links & Resources) to `--content-max` so they align with their content blocks

## Test plan
- [ ] Desktop 1440px: sim header left-aligned, all headings align with section content
- [ ] All text flows within consistent `--content-max` containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)