### PR TITLE
Restore hero width, remove sim legend

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -70,9 +70,6 @@ import LinksResources from '../components/sections/LinksResources.astro';
             </div>
           </div>
         </div>
-        <p class="sim-legend font-mono">
-          principal = human · agent = LLM delegate · vault = protocol execution
-        </p>
       </div>
       <Simulation />
     </section>
@@ -96,10 +93,6 @@ import LinksResources from '../components/sections/LinksResources.astro';
   .hero {
     padding: var(--space-3xl) 0 var(--space-2xl);
     border-bottom: 1px solid var(--color-border-subtle);
-  }
-
-  .hero > .container {
-    max-width: var(--content-max);
   }
 
   .hero__title {
@@ -289,15 +282,6 @@ import LinksResources from '../components/sections/LinksResources.astro';
     color: var(--color-text-dim);
     min-width: 72px;
     text-align: right;
-  }
-
-  .sim-legend {
-    font-size: var(--text-xs);
-    color: var(--color-text-dim);
-    letter-spacing: 0.02em;
-    margin-top: var(--space-sm);
-    max-width: var(--content-max);
-    margin: var(--space-sm) auto 0;
   }
 
   @media (max-width: 1023px) {


### PR DESCRIPTION
## Summary
- Remove `max-width: var(--content-max)` override on hero container — hero now uses standard 1400px container like other sections
- Remove "principal = human · agent = LLM delegate · vault = protocol execution" legend line and its CSS

## Test plan
- [ ] Desktop: hero width matches other sections
- [ ] Legend line no longer appears below sim controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)