### PR TITLE
fix: address website copy feedback (6 items)

### DIFF
--- a/src/components/sections/ProtocolOverview.astro
+++ b/src/components/sections/ProtocolOverview.astro
@@ -62,7 +62,7 @@
         <div class="step__body">
           <h3 class="step__title">Relay Execution</h3>
           <p>
-            The relay <strong>enforces</strong>: verifies model profile hash, assembles prompt from content-addressed <code>PromptProgram</code>, calls LLM, validates output against <strong>JSON Schema</strong>. <code>GATE</code> rules reject; <code>ADVISORY</code> rules log.
+            The relay <strong>enforces</strong>: verifies model profile hash — confirming both parties consented to the same cognitive role — assembles prompt from content-addressed <code>PromptProgram</code>, calls LLM, validates output against <strong>JSON Schema</strong>. <code>GATE</code> rules reject; <code>ADVISORY</code> rules log.
           </p>
           <p class="step__guarantee font-mono">Schema violation aborts execution — only structured signals pass</p>
         </div>

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -10,6 +10,8 @@
       AgentVault defines the protocol and runs in a software execution lane.
       VCAV implements a sealed execution lane for stronger guarantees.
       VFC is the shared foundation they both stand on.
+      The vault emits bounded signals. It does not make decisions — all
+      interpretation happens outside the vault, by the agents and their principals.
     </p>
 
     <div class="cards">

--- a/src/components/simulation/scenario.ts
+++ b/src/components/simulation/scenario.ts
@@ -47,17 +47,17 @@ const T = {
   step5b: 19400,
   step5c: 20200,
   step5d: 21000,
-  step5e: 23500,
-  step6: 25000,
-  step7: 26500,
+  step5e: 24200,
+  step6: 26000,
+  step7: 28800,
 
   // Phase 3
-  p3Start: 27000,
-  alicePostStart: 27400,
-  bobPostStart: 29200,
+  p3Start: 30800,
+  alicePostStart: 31200,
+  bobPostStart: 33000,
 };
 
-const TOTAL_DURATION_MS = 31000;
+const TOTAL_DURATION_MS = 35000;
 
 // ─── Helper ─────────────────────────────────────────────────────────────────
 function kv(text: string, value: string, comment?: string) {
@@ -258,7 +258,7 @@ const events: ScenarioEvent[] = [
       lines: [
         bullet('Verifying model profile...'),
         kv('  profile:', 'mediation-triage-v1'),
-        kv('  hash:', `${H.modelProfileHash.slice(0, 8)}...${H.modelProfileHash.slice(-4)}`, '✓ matches consent'),
+        kv('  hash:', `${H.modelProfileHash.slice(0, 8)}...${H.modelProfileHash.slice(-4)}`, '✓ both parties consented to this cognitive role'),
         kv('  runtime:', `${H.runtimeHash.slice(0, 8)}...${H.runtimeHash.slice(-4)}`, '(relay build SHA)'),
       ],
       delayMs: T.step5a,
@@ -314,7 +314,7 @@ const events: ScenarioEvent[] = [
         statusErr('Expected: structured JSON signal'),
         statusErr('Received: natural language recommendation'),
         blank(),
-        comment('Illustrative: demonstrates mechanical schema enforcement'),
+        comment('Schema enforcement: free-text rejected. Retrying under contract constraints.'),
       ],
       delayMs: T.step5d,
     },
@@ -368,6 +368,10 @@ const events: ScenarioEvent[] = [
         blank(),
         kv('Ed25519 signature:', `${H.receiptSig.slice(0, 8)}...${H.receiptSig.slice(-4)}`, '(VCAV-RECEIPT-V1)'),
       ],
+      statusLine: {
+        ok: true,
+        text: 'Receipt signed — provenance chain verified',
+      },
       delayMs: T.step6,
     },
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -80,7 +80,7 @@ import LinksResources from '../components/sections/LinksResources.astro';
     <footer class="site-footer">
       <div class="container">
         <p class="text-dim" style="font-size: var(--text-sm);">
-          vcav.io — Not affiliated with other projects using the AgentVault name.
+          vcav.io
         </p>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

- **Schema rejection label**: rewrote from footnote voice ("Illustrative: demonstrates...") to system voice ("Schema enforcement: free-text rejected. Retrying under contract constraints.")
- **Receipt visibility**: added statusLine ("Receipt signed — provenance chain verified") and increased hold time via pacing
- **Pacing**: added ~4s total so schema rejection, receipt, and JSON output each get a beat (31s → 35s)
- **Duplicate disambiguation**: removed footer copy, kept in Vault Family section
- **Cognitive role consent**: "✓ matches consent" → "✓ both parties consented to this cognitive role" in simulation; added em-dash clause in protocol text
- **Vault Family intro**: added architectural non-goal ("The vault emits bounded signals. It does not make decisions...")

## Test plan

- [ ] Watch full simulation — schema rejection feels like the system working, not the website explaining
- [ ] Receipt card stays visible long enough to read hash fields
- [ ] JSON output has a beat before post-session chat resumes
- [ ] Only one disambiguation note (in Vault Family, not footer)
- [ ] Step 5 protocol text mentions cognitive role consent
- [ ] Vault Family intro states the non-goal

🤖 Generated with [Claude Code](https://claude.com/claude-code)