### PR TITLE
copy: revise website text for clarity and co-founder scenario

### DIFF
--- a/src/components/sections/LinksResources.astro
+++ b/src/components/sections/LinksResources.astro
@@ -27,7 +27,7 @@
       </li>
       <li class="resource">
         <span class="resource__label">VFC (Vault Family Common)</span>
-        <span class="resource__soon">Coming soon — github.com/vcav-io/vfc</span>
+        <span class="resource__soon">Coming soon</span>
       </li>
       <li class="resource">
         <span class="resource__label">Protocol specification</span>

--- a/src/components/sections/PositioningText.astro
+++ b/src/components/sections/PositioningText.astro
@@ -7,25 +7,28 @@
   <div class="container">
     <div class="positioning">
       <p>
-        People already ask their AI assistants to draft difficult messages, navigate
-        conflicts, and make decisions on their behalf. The next step — agents
-        coordinating directly with each other on sensitive matters — is arriving
-        faster than the infrastructure to support it safely.
+        When AI agents coordinate about sensitive matters, each carries private context
+        from its user — strategic intent, financial constraints, personal plans, internal
+        disagreements.
       </p>
       <p>
-        When that coordination happens, discretion collapses. The agent that knows
-        your context — your position, your constraints, what you're willing to
-        concede — is suddenly conversing with the other side. Prompt engineering
-        can't fix this. Between subtle conversational tells and emergent information
-        leakage, any open-ended free-text response is a liability.
+        Direct cross-agent reasoning is useful. It allows coordination, mediation,
+        negotiation.
       </p>
       <p>
-        AgentVault solves this mechanically. A JSON Schema limits what the model can
-        express — output that doesn't validate is rejected, not returned. The relay
-        enforces constraints at the infrastructure layer. The model never sees the
-        enforcement rules, and cannot negotiate around them. Every session produces
-        a signed receipt proving exactly which contract, policy, and model governed
-        execution.
+        But without a boundary layer, that reasoning collapses separation.
+        Personal context becomes shared state between parties.
+      </p>
+      <p>
+        AgentVault separates reasoning from disclosure.
+      </p>
+      <p>
+        Agents may reason internally over their user's context.
+        Only a bounded, schema-defined signal is allowed to cross to the other side.
+      </p>
+      <p>
+        The boundary is mechanical, not social.
+        It does not rely on discretion. It constrains what can be expressed.
       </p>
     </div>
   </div>

--- a/src/components/sections/ProtocolOverview.astro
+++ b/src/components/sections/ProtocolOverview.astro
@@ -9,7 +9,7 @@
     <p class="intro text-secondary">
       Seven steps from discovery to receipt. Each cryptographically bound to the
       previous. Contracts are pre-existing documents referenced by hash — not
-      negotiated in-protocol.
+      negotiated mid-session.
     </p>
 
     <ol class="steps">
@@ -18,31 +18,30 @@
         <div class="step__body">
           <h3 class="step__title">Discovery</h3>
           <p>
-            Agents publish <strong>signed descriptors</strong> — Ed25519 keys, capabilities, model profiles. Signatures use domain separation (<code>VCAV-DESCRIPTOR-V1:</code>).
+            Agents publish <strong>signed descriptors</strong> — Ed25519 keys, capabilities, model profiles.
           </p>
-          <p class="step__guarantee font-mono">Domain-separated signatures prevent cross-context descriptor reuse</p>
         </div>
       </li>
 
       <li class="step">
         <span class="step__number">2</span>
         <div class="step__body">
-          <h3 class="step__title">Proposal</h3>
+          <h3 class="step__title">Invite</h3>
           <p>
-            Initiator sends <code>PROPOSE</code> referencing a <strong>content-addressed contract</strong> by SHA-256 hash — purpose code, output schema, model profile, and execution lane.
+            Initiator references a <strong>content-addressed contract</strong> by hash —
+            purpose code, output schema, model profile.
           </p>
-          <p class="step__guarantee font-mono">Content-addressed contract — immutable reference, not in-protocol negotiation</p>
         </div>
       </li>
 
       <li class="step">
         <span class="step__number">3</span>
         <div class="step__body">
-          <h3 class="step__title">Admission</h3>
+          <h3 class="step__title">Accept / Decline</h3>
           <p>
-            Responder issues <code>ADMIT</code> with a <strong>one-time admit token</strong>, confirming the same contract hash — or <code>DENY</code> with no reason field.
+            Responder verifies the contract hash and accepts. Decline is constant-shape —
+            no reason field, no additional information.
           </p>
-          <p class="step__guarantee font-mono">Designed so that denial is constant-shape — no reason field, no information leakage</p>
         </div>
       </li>
 
@@ -51,9 +50,8 @@
         <div class="step__body">
           <h3 class="step__title">Commitment</h3>
           <p>
-            Encrypted inputs submitted via admit token. <strong><code>XChaCha20-Poly1305</code></strong> with AAD binding ciphertext to the contract hash.
+            Encrypted inputs are submitted and bound to the contract hash.
           </p>
-          <p class="step__guarantee font-mono">Encryption with AAD binding — ciphertext is tied to the contract hash</p>
         </div>
       </li>
 
@@ -62,9 +60,9 @@
         <div class="step__body">
           <h3 class="step__title">Relay Execution</h3>
           <p>
-            The relay <strong>enforces</strong>: verifies model profile hash — confirming both parties consented to the same cognitive role — assembles prompt from content-addressed <code>PromptProgram</code>, calls LLM, validates output against <strong>JSON Schema</strong>. <code>GATE</code> rules reject; <code>ADVISORY</code> rules log.
+            Model profile verified. Output validated against <strong>JSON Schema</strong>.
+            Only structured signals pass.
           </p>
-          <p class="step__guarantee font-mono">Schema violation aborts execution — only structured signals pass</p>
         </div>
       </li>
 
@@ -73,9 +71,9 @@
         <div class="step__body">
           <h3 class="step__title">Receipt</h3>
           <p>
-            <strong>Ed25519 signed receipt</strong> binding contract hash, guardian policy, prompt template, model identity, model profile, relay build SHA, participants, and output signal.
+            An <strong>Ed25519-signed receipt</strong> binds contract hash, guardian policy,
+            prompt template, model identity, and output signal.
           </p>
-          <p class="step__guarantee font-mono">Any change to any bound input invalidates the receipt</p>
         </div>
       </li>
 
@@ -84,12 +82,17 @@
         <div class="step__body">
           <h3 class="step__title">Output Retrieval</h3>
           <p>
-            Both agents retrieve the <strong>bounded output signal</strong> and receipt. The signal is structured data — each agent interprets it for its principal outside the vault.
+            Both agents retrieve the bounded signal and receipt. Interpretation happens
+            outside the vault.
           </p>
-          <p class="step__guarantee font-mono">Structured signal, not natural language — agents interpret for their principal</p>
         </div>
       </li>
     </ol>
+
+    <p class="protocol-coda text-secondary">
+      The vault emits compressed informational signals.
+      It does not make decisions.
+    </p>
   </div>
 </section>
 
@@ -166,5 +169,12 @@
     color: var(--color-accent-dim);
     letter-spacing: 0.02em;
     margin-top: var(--space-xs);
+  }
+
+  .protocol-coda {
+    max-width: var(--content-max);
+    margin: var(--space-2xl) auto 0;
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
   }
 </style>

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -7,11 +7,17 @@
   <div class="container">
     <h2>The Vault Family</h2>
     <p class="intro text-secondary">
-      AgentVault defines the protocol and runs in a software execution lane.
-      VCAV implements a sealed execution lane for stronger guarantees.
-      VFC is the shared foundation they both stand on.
-      The vault emits bounded signals. It does not make decisions — all
-      interpretation happens outside the vault, by the agents and their principals.
+      AgentVault defines the open protocol and runs in a software execution lane.
+      VCAV implements a sealed execution lane with stronger isolation guarantees.
+      VFC (Vault Family Common) provides shared cryptographic primitives and receipt semantics.
+    </p>
+    <p class="intro text-secondary principles">
+      All share the same principle:
+      bound internal reasoning, bounded external disclosure, verifiable enforcement.
+    </p>
+    <p class="intro text-secondary">
+      AgentVault is the coordination layer.
+      VCAV is the higher-assurance boundary.
     </p>
 
     <div class="cards">
@@ -26,9 +32,8 @@
           >vcav-io/agentvault</a>
         </div>
         <p class="card__description">
-          The open protocol. Defines how agents discover, contract, submit, and receive
-          bounded signals with provenance receipts. The relay enforces contracts, validates
-          outputs against schema, applies guardian rules, and signs receipts.
+          Open protocol for bounded agent-to-agent coordination. The relay enforces contracts,
+          validates schema-constrained outputs, applies guardian rules, and signs receipts.
         </p>
         <div class="card__tag card__tag--primary">Open protocol</div>
       </div>
@@ -39,9 +44,8 @@
           <span class="card__link card__link--muted">vcav-io/vfc — coming soon</span>
         </div>
         <p class="card__description">
-          Vault Family Common. Shared cryptographic primitives, AFAL wire types,
-          receipt signing, and IFC label algebra. The core data structures that
-          make receipts interoperable.
+          Shared receipt envelope, cryptographic primitives, AFAL wire types,
+          and IFC label algebra. Ensures interoperability across the vault family.
         </p>
         <div class="card__tag">Shared foundation</div>
       </div>
@@ -52,8 +56,8 @@
           <span class="card__badge">Private — in development</span>
         </div>
         <p class="card__description">
-          Verifiable Confidential Agent Vault. A hardware-backed sealed execution lane
-          with stronger isolation guarantees. Same protocol, higher assurance boundary.
+          Hardware-backed sealed execution lane with stronger isolation guarantees.
+          Same protocol, higher assurance boundary.
         </p>
         <div class="card__tag">Sealed execution</div>
       </div>

--- a/src/components/simulation/scenario.ts
+++ b/src/components/simulation/scenario.ts
@@ -6,9 +6,9 @@ import type { Scenario, ScenarioEvent } from './types.ts';
 
 // ─── Consistent fake hashes ────────────────────────────────────────────────
 const H = {
-  proposalId:        'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f07890',
+  inviteId:          'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f07890',
   contractHash:      '9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a009876',
-  admitTokenId:      'f0e1d2c3b4a59687f8e9d0c1b2a394857065f4e3d2c1b0a9f8e7d6c5b4a31234',
+  submitToken:       'f0e1d2c3b4a59687f8e9d0c1b2a394857065f4e3d2c1b0a9f8e7d6c5b4a31234',
   modelProfileHash:  'e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d42345',
   promptProgramHash: 'd4c3b2a1f0e9d8c7b6a5f4e3d2c1b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e57890',
   guardianPolicy:    'c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b27890',
@@ -91,14 +91,14 @@ const events: ScenarioEvent[] = [
     event: { phase: 'pre-session', delayMs: T.p1Start },
   },
 
-  // Alice types her message
+  // Alice tells her agent
   {
     type: 'chat',
     event: {
       panel: 'left',
       sender: 'user',
       name: 'Alice',
-      text: "Contract dispute. I delivered on time but scope expanded beyond the original agreement. The extra work was worth $40k \u2014 my floor is $25k. Don\u2019t disclose either number.",
+      text: "I co-founded a startup with Bob 18 months ago and we\u2019re growing apart on strategy. I think we need to pivot to enterprise. I\u2019ve been approached about an acqui-hire. Don\u2019t disclose that. Start mediation.",
       delayMs: T.aliceTypingStart,
     },
   },
@@ -110,31 +110,31 @@ const events: ScenarioEvent[] = [
       panel: 'left',
       sender: 'bot',
       name: 'AliceBot',
-      text: "Opening a vault session under mediation-triage. The output will be a compatibility signal \u2014 not a recommendation. Your floor stays sealed.",
+      text: "Initiating mediation via the relay. The output will be a bounded signal. Your private context stays inside the boundary.",
       delayMs: T.aliceBotStart,
     },
   },
 
-  // Bob types
+  // Bob asks his agent for help
   {
     type: 'chat',
     event: {
       panel: 'right',
       sender: 'user',
       name: 'Bob',
-      text: "Scope dispute with a contractor. Some of the \u2018scope creep\u2019 was correcting defects. I\u2019ve budgeted up to $18k to settle \u2014 keep that number private.",
+      text: "We\u2019re disagreeing about enterprise vs developer focus. I\u2019ve been exploring other options if we pivot. I want to make it work.",
       delayMs: T.bobTypingStart,
     },
   },
 
-  // BobBot responds
+  // BobBot finds the invite
   {
     type: 'chat',
     event: {
       panel: 'right',
       sender: 'bot',
       name: 'BobBot',
-      text: "Joining the session. Output is a structured compatibility signal \u2014 your settlement budget won\u2019t be disclosed.",
+      text: "Invite received. Contract verified. Bounded signal only \u2014 your private context won\u2019t be shared.",
       delayMs: T.bobBotStart,
     },
   },
@@ -168,55 +168,57 @@ const events: ScenarioEvent[] = [
     },
   },
 
-  // Step 2 — Proposal
+  // Step 2 — Invite Created
   {
     type: 'protocol-card',
     event: {
       id: 'step-2',
       stepLabel: 'Step 2',
-      title: 'Proposal',
+      title: 'Invite Created',
       lines: [
-        heading('PROPOSE'),
+        heading('CREATE_INVITE'),
         blank(),
-        kv('proposal_id:', `${H.proposalId.slice(0, 8)}...${H.proposalId.slice(-4)}`),
+        kv('invite_id:', `${H.inviteId.slice(0, 8)}...${H.inviteId.slice(-4)}`),
         kv('from:', 'alicebot-prod-7'),
         kv('to:', 'bobbot-prod-3'),
         kv('purpose_code:', 'MEDIATION'),
-        kv('lane_id:', 'API_MEDIATED'),
         kv('model_profile:', 'mediation-triage-v1'),
         kv('  hash:', `${H.modelProfileHash.slice(0, 8)}...${H.modelProfileHash.slice(-4)}`),
         kv('output_schema:', 'mediation_compat_signal_v1'),
-        kv('contract ref:', `${H.contractHash.slice(0, 8)}...${H.contractHash.slice(-4)}`),
+        kv('contract_hash:', `${H.contractHash.slice(0, 8)}...${H.contractHash.slice(-4)}`),
+        kv('status:', 'PENDING'),
       ],
       statusLine: {
         ok: true,
-        text: `→ Proposal sent   sig: ${H.alicePropSig.slice(0, 8)}...${H.alicePropSig.slice(-4)}`,
+        text: `→ Deposited in relay inbox   sig: ${H.alicePropSig.slice(0, 8)}...${H.alicePropSig.slice(-4)}`,
       },
       delayMs: T.step2,
     },
   },
 
-  // Step 3 — Admission
+  // Step 3 — Invite Accepted
   {
     type: 'protocol-card',
     event: {
       id: 'step-3',
       stepLabel: 'Step 3',
-      title: 'Admission',
+      title: 'Invite Accepted',
       lines: [
-        heading('ADMIT'),
+        heading('ACCEPT_INVITE'),
         blank(),
-        kv('proposal_id:', `${H.proposalId.slice(0, 8)}...${H.proposalId.slice(-4)}`, '← echoed'),
-        kv('outcome:', 'ADMIT'),
-        kv('contract_hash:', `${H.contractHash.slice(0, 8)}...${H.contractHash.slice(-4)}`, '← same contract'),
-        kv('admit_token_id:', `${H.admitTokenId.slice(0, 8)}...${H.admitTokenId.slice(-4)}`, '← one-time token'),
-        kv('model_profile:', `${H.modelProfileHash.slice(0, 8)}...${H.modelProfileHash.slice(-4)}`, '← confirmed'),
-        kv('lane_id:', 'API_MEDIATED'),
+        kv('invite_id:', `${H.inviteId.slice(0, 8)}...${H.inviteId.slice(-4)}`, '← from inbox'),
+        kv('contract_hash:', `${H.contractHash.slice(0, 8)}...${H.contractHash.slice(-4)}`, '← verified'),
+        kv('status:', 'ACCEPTED'),
+        blank(),
+        heading('SESSION CREATED'),
+        kv('session_id:', `${H.sessionId.slice(0, 8)}...${H.sessionId.slice(-4)}`),
+        kv('execution_lane:', 'API_MEDIATED'),
+        kv('responder_submit_token:', `${H.submitToken.slice(0, 8)}...${H.submitToken.slice(-4)}`, '← Bob only sees his role'),
       ],
       statusLine: {
         ok: true,
-        text: 'Admission granted',
-        note: 'DENY would be constant-shape — no reason field',
+        text: 'Invite accepted — session established',
+        note: 'DECLINE would be constant-shape — no reason field',
       },
       delayMs: T.step3,
     },
@@ -231,13 +233,13 @@ const events: ScenarioEvent[] = [
       title: 'Commitment',
       lines: [
         heading('COMMIT (AliceBot)'),
-        kv('admit_token:', `${H.admitTokenId.slice(0, 8)}...${H.admitTokenId.slice(-4)}`),
+        kv('submit_token:', `${H.submitToken.slice(0, 8)}...${H.submitToken.slice(-4)}`),
         kv('encrypted_input:', `${H.aliceEncInput.slice(0, 8)}...${H.aliceEncInput.slice(-4)}`),
         comment('← encrypted with XChaCha20-Poly1305'),
         comment('← AAD binds to contract hash'),
         blank(),
         heading('COMMIT (BobBot)'),
-        kv('admit_token:', `${H.admitTokenId.slice(0, 8)}...${H.admitTokenId.slice(-4)}`),
+        kv('submit_token:', `${H.submitToken.slice(0, 8)}...${H.submitToken.slice(-4)}`),
         kv('encrypted_input:', `${H.bobEncInput.slice(0, 8)}...${H.bobEncInput.slice(-4)}`),
       ],
       statusLine: {
@@ -384,8 +386,8 @@ const events: ScenarioEvent[] = [
       json: JSON.stringify({
         compatibility_signal: 'PARTIAL_ALIGNMENT',
         friction_band: 'HIGH',
-        aligned_dimensions: ['timeline', 'scope'],
-        divergent_dimensions: ['liability', 'compensation'],
+        aligned_dimensions: ['company_commitment', 'growth_ambition'],
+        divergent_dimensions: ['revenue_strategy', 'product_direction'],
         escalation_required: true,
       }, null, 2),
     },
@@ -404,7 +406,7 @@ const events: ScenarioEvent[] = [
       panel: 'left',
       sender: 'bot',
       name: 'AliceBot',
-      text: "Signal received. Timeline and scope aligned. Liability and compensation diverge \u2014 escalation flagged.",
+      text: "Signal returned. Alignment on commitment to the company. Strategy direction diverges \u2014 escalation recommended.",
       delayMs: T.alicePostStart,
     },
   },
@@ -416,7 +418,7 @@ const events: ScenarioEvent[] = [
       panel: 'right',
       sender: 'bot',
       name: 'BobBot',
-      text: "Aligned on timeline and scope. Liability and compensation diverge \u2014 escalation required.",
+      text: "Result: partial alignment on company commitment. Revenue strategy and product direction diverge \u2014 structured negotiation recommended.",
       delayMs: T.bobPostStart,
     },
   },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,12 +14,19 @@ import LinksResources from '../components/sections/LinksResources.astro';
         <div class="hero__content">
           <h1 class="hero__title">AgentVault</h1>
           <p class="hero__claim">
-            When your AI agent negotiates on your behalf, what stops it from saying too much?
+            AI agents are beginning to act as delegates.
+          </p>
+          <p class="hero__claim hero__claim--sub">
+            Each carries sensitive personal context from its user.<br>
+            If agents reason directly together, that context becomes shared by default.
+          </p>
+          <p class="hero__claim hero__claim--sub">
+            AgentVault inserts a boundary.
           </p>
           <ul class="hero__guarantees font-mono">
-            <li>Schema-enforced output limits — not prompting, infrastructure</li>
-            <li>Cryptographic receipts — tamper-evident proof of what happened</li>
-            <li>Content-addressed contracts — immutable, independently verifiable</li>
+            <li>Schema-enforced output limits — infrastructure, not prompting</li>
+            <li>Cryptographic receipts — verifiable proof of what occurred</li>
+            <li>Content-addressed contracts — immutable execution context</li>
           </ul>
           <div class="hero__ctas">
             <a href="https://github.com/vcav-io/agentvault" class="hero__cta" target="_blank" rel="noopener noreferrer">View on GitHub</a>
@@ -37,9 +44,9 @@ import LinksResources from '../components/sections/LinksResources.astro';
           <div class="sim-module-header__text">
             <h2 class="sim-module-header__title">Mediation Triage Demo</h2>
             <p class="sim-module-header__subtitle text-secondary">
-              Two agents coordinate on a contract dispute. Watch the protocol enforce bounded
-              disclosure — structured outputs, schema validation, cryptographic receipts.
-              This is a scripted walkthrough.
+              Two co-founders disagree on strategy. Their agents coordinate using private context.
+              The protocol enforces bounded disclosure — structured outputs, schema validation,
+              cryptographic receipts. Scripted walkthrough.
             </p>
           </div>
           <div class="sim-module-header__controls">
@@ -112,6 +119,11 @@ import LinksResources from '../components/sections/LinksResources.astro';
     color: var(--color-text-secondary);
     max-width: none;
     margin-bottom: var(--space-md);
+  }
+
+  .hero__claim--sub {
+    font-size: var(--text-base);
+    margin-bottom: var(--space-sm);
   }
 
   .hero__guarantees {


### PR DESCRIPTION
## Summary
- Rewrite simulation chat to co-founder mediation scenario (from real test transcripts)
- Expand positioning text to 6 focused paragraphs on bounded disclosure
- Simplify all 7 protocol step descriptions, add coda paragraph
- Tighten vault family card copy (VFC, VCAV descriptions)
- Remove premature VFC GitHub link from resources section
- Restructure hero claims into multi-paragraph flow

## Test plan
- [x] `npm run build` passes
- [x] Visual verification on localhost — all sections render correctly
- [ ] Play full simulation end-to-end, verify chat messages match scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)