### PR TITLE
style: align protocol step numbers with title text

### DIFF
--- a/src/components/sections/ProtocolOverview.astro
+++ b/src/components/sections/ProtocolOverview.astro
@@ -147,7 +147,7 @@
     color: var(--color-accent);
     background: var(--color-vault-bg);
     flex-shrink: 0;
-    margin-top: 0.1rem;
+    margin-top: -0.1rem;
   }
 
   .step__title {


### PR DESCRIPTION
## Summary
- Shift number circles up slightly (margin-top 0.1rem → -0.1rem) so their visual center matches the step title baseline

## Test plan
- [x] Visual verification on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)