### PR TITLE
feat: add AV and VCAV logos across the site

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,5 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="4" fill="#0a0a0f"/>
-  <path d="M8 12 L16 8 L24 12 L24 20 L16 24 L8 20Z" fill="none" stroke="#4a9da8" stroke-width="1.5"/>
-  <circle cx="16" cy="16" r="3" fill="#4a9da8"/>
+  <g transform="translate(3.5, 3.5) scale(0.5)">
+    <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#ededeb" stroke-width="2" stroke-linecap="round"/>
+    <rect x="23" y="0" width="4" height="50" rx="1" fill="#ededeb"/>
+    <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#ededeb" stroke-width="2" stroke-linecap="round"/>
+  </g>
 </svg>

--- a/public/logos/dark-mono.svg
+++ b/public/logos/dark-mono.svg
@@ -1,0 +1,14 @@
+<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(50, 40)">
+    <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+    <rect x="23" y="0" width="4" height="50" rx="1" fill="#FFFFFF"/>
+    <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
+    <text x="65" y="25" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+  </g>
+  <g transform="translate(50, 110)">
+    <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"/>
+    <rect x="21" y="0" width="8" height="50" rx="1" fill="#FFFFFF"/>
+    <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"/>
+    <text x="65" y="25" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+  </g>
+</svg>

--- a/public/logos/light-mono.svg
+++ b/public/logos/light-mono.svg
@@ -1,0 +1,14 @@
+<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(50, 40)">
+    <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#2F2F2F" stroke-width="2" stroke-linecap="round"/>
+    <rect x="23" y="0" width="4" height="50" rx="1" fill="#2F2F2F"/>
+    <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#2F2F2F" stroke-width="2" stroke-linecap="round"/>
+    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+  </g>
+  <g transform="translate(50, 110)">
+    <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
+    <rect x="21" y="0" width="8" height="50" rx="1" fill="#2F2F2F"/>
+    <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
+    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+  </g>
+</svg>

--- a/public/logos/optimized.svg
+++ b/public/logos/optimized.svg
@@ -1,0 +1,15 @@
+<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(50, 40)">
+    <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#708090" stroke-width="2" stroke-linecap="round"/>
+    <rect x="23" y="0" width="4" height="50" rx="1" fill="#2F2F2F"/>
+    <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#708090" stroke-width="2" stroke-linecap="round"/>
+    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+  </g>
+
+  <g transform="translate(50, 110)">
+    <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
+    <rect x="21" y="0" width="8" height="50" rx="1" fill="#2F2F2F"/>
+    <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
+    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+  </g>
+</svg>

--- a/src/components/icons/AVMark.astro
+++ b/src/components/icons/AVMark.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: className } = Astro.props;
+---
+
+<svg
+  class={className}
+  viewBox="0 0 50 50"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <rect x="23" y="0" width="4" height="50" rx="1" fill="currentColor"/>
+  <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/icons/VCAVMark.astro
+++ b/src/components/icons/VCAVMark.astro
@@ -1,0 +1,18 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: className } = Astro.props;
+---
+
+<svg
+  class={className}
+  viewBox="0 0 50 50"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  aria-hidden="true"
+>
+  <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="currentColor" stroke-width="2" stroke-linecap="square"/>
+  <rect x="21" y="0" width="8" height="50" rx="1" fill="currentColor"/>
+  <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="currentColor" stroke-width="2" stroke-linecap="square"/>
+</svg>

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -1,6 +1,8 @@
 ---
 // VaultFamily.astro
 // Three components: AgentVault (primary), VFC (neutral), VCAV (muted)
+import AVMark from '../icons/AVMark.astro';
+import VCAVMark from '../icons/VCAVMark.astro';
 ---
 
 <section class="section section--alt reveal" id="family">
@@ -22,7 +24,10 @@
     <div class="cards">
       <div class="card card--primary">
         <div class="card__header">
-          <h3 class="card__name">AgentVault</h3>
+          <div class="card__name-row">
+            <AVMark class="card__icon" />
+            <h3 class="card__name">AgentVault</h3>
+          </div>
           <a
             href="https://github.com/vcav-io/agentvault"
             class="card__link"
@@ -40,7 +45,10 @@
 
       <div class="card card--muted">
         <div class="card__header">
-          <h3 class="card__name">VCAV</h3>
+          <div class="card__name-row">
+            <VCAVMark class="card__icon" />
+            <h3 class="card__name">VCAV</h3>
+          </div>
           <span class="card__badge">Private — in development</span>
         </div>
         <p class="card__description">
@@ -127,6 +135,27 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-xs);
+  }
+
+  .card__name-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  :global(.card__icon) {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    color: var(--color-text-secondary);
+  }
+
+  .card--primary :global(.card__icon) {
+    color: var(--color-accent);
+  }
+
+  .card--muted :global(.card__icon) {
+    color: var(--color-text-dim);
   }
 
   .card__name {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,14 +6,18 @@ import ProtocolOverview from '../components/sections/ProtocolOverview.astro';
 import VaultFamily from '../components/sections/VaultFamily.astro';
 import LinksResources from '../components/sections/LinksResources.astro';
 import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
+import AVMark from '../components/icons/AVMark.astro';
 ---
 
 <Layout>
+  <a href="#" class="site-mark" aria-label="AgentVault">
+    <AVMark class="site-mark__icon" />
+  </a>
   <main>
     <header class="hero">
       <div class="container">
         <div class="hero__content">
-          <h1 class="hero__title">AgentVault</h1>
+          <h1 class="hero__title"><AVMark class="hero__mark" />AgentVault</h1>
           <p class="hero__claim">
             AI agents are becoming delegates.
           </p>
@@ -107,6 +111,26 @@ import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
 </Layout>
 
 <style>
+  .site-mark {
+    position: fixed;
+    top: var(--space-lg);
+    left: var(--space-lg);
+    z-index: 100;
+    display: block;
+    opacity: 0.5;
+    color: var(--color-text);
+    transition: opacity var(--duration-fast) var(--ease-out);
+  }
+
+  .site-mark:hover {
+    opacity: 1;
+  }
+
+  :global(.site-mark__icon) {
+    width: 24px;
+    height: 24px;
+  }
+
   .hero {
     padding: var(--space-3xl) 0 var(--space-2xl);
     border-bottom: 1px solid var(--color-border-subtle);
@@ -118,11 +142,21 @@ import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
   }
 
   .hero__title {
+    display: flex;
+    align-items: center;
+    gap: 0.3em;
     font-size: clamp(2.5rem, 5vw, 3.5rem);
     font-weight: 700;
     letter-spacing: -0.03em;
     color: var(--color-text);
     margin-bottom: var(--space-lg);
+  }
+
+  :global(.hero__mark) {
+    height: 0.85em;
+    width: auto;
+    flex-shrink: 0;
+    color: var(--color-accent);
   }
 
   .hero__claim {


### PR DESCRIPTION
## Summary
- Add AV mark (teal) inline with hero title + subtle sticky nav mark in top-left
- Add AV and VCAV icon marks to Vault Family card headers
- Replace hexagonal favicon with AV mark on dark background
- Save all 3 logo SVG variants (optimized, light mono, dark mono) in `public/logos/`
- New reusable `AVMark.astro` and `VCAVMark.astro` icon components using `currentColor`

## Test plan
- [ ] Hero renders mark + text at correct size across viewports
- [ ] Sticky mark visible top-left, hover to full opacity
- [ ] VaultFamily cards show icons (teal on AV, dim on VCAV, none on VFC)
- [ ] Favicon displays correctly in browser tab
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)