### PR TITLE
docs: update logo variant proportions

### DIFF
--- a/public/logos/dark-mono.svg
+++ b/public/logos/dark-mono.svg
@@ -1,14 +1,14 @@
-<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(50, 40)">
+<svg viewBox="-1 -8 370 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
     <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
     <rect x="23" y="0" width="4" height="50" rx="1" fill="#FFFFFF"/>
     <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round"/>
-    <text x="65" y="25" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+    <text x="65" y="20" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 54px; font-weight: 400;">agentvault</text>
   </g>
-  <g transform="translate(50, 110)">
+  <g transform="translate(0, 70)">
     <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"/>
     <rect x="21" y="0" width="8" height="50" rx="1" fill="#FFFFFF"/>
     <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="#FFFFFF" stroke-width="2" stroke-linecap="square"/>
-    <text x="65" y="25" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+    <text x="65" y="25" fill="#FFFFFF" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 54px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
   </g>
 </svg>

--- a/public/logos/light-mono.svg
+++ b/public/logos/light-mono.svg
@@ -1,14 +1,14 @@
-<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(50, 40)">
+<svg viewBox="-1 -8 370 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
     <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#2F2F2F" stroke-width="2" stroke-linecap="round"/>
     <rect x="23" y="0" width="4" height="50" rx="1" fill="#2F2F2F"/>
     <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#2F2F2F" stroke-width="2" stroke-linecap="round"/>
-    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+    <text x="65" y="20" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 54px; font-weight: 400;">agentvault</text>
   </g>
-  <g transform="translate(50, 110)">
+  <g transform="translate(0, 70)">
     <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
     <rect x="21" y="0" width="8" height="50" rx="1" fill="#2F2F2F"/>
     <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
-    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 54px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
   </g>
 </svg>

--- a/public/logos/optimized.svg
+++ b/public/logos/optimized.svg
@@ -1,15 +1,14 @@
-<svg width="600" height="180" viewBox="0 0 600 180" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <g transform="translate(50, 40)">
+<svg viewBox="-1 -8 370 140" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g>
     <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="#708090" stroke-width="2" stroke-linecap="round"/>
     <rect x="23" y="0" width="4" height="50" rx="1" fill="#2F2F2F"/>
     <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="#708090" stroke-width="2" stroke-linecap="round"/>
-    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 400;">agentvault</text>
+    <text x="65" y="20" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 54px; font-weight: 400;">agentvault</text>
   </g>
-
-  <g transform="translate(50, 110)">
+  <g transform="translate(0, 70)">
     <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
     <rect x="21" y="0" width="8" height="50" rx="1" fill="#2F2F2F"/>
     <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="#2F2F2F" stroke-width="2" stroke-linecap="square"/>
-    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+    <text x="65" y="25" fill="#2F2F2F" dominant-baseline="central" style="font-family: 'Inter', sans-serif; font-size: 54px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Update logo variant SVGs in public/logos/ with new proportions (54px text to match icon)
- Tight viewBox, no fixed dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)