### PR TITLE
feat: SVG lockup in hero, VCAV mark for nav

### DIFF
--- a/src/components/icons/AVLockup.astro
+++ b/src/components/icons/AVLockup.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: className } = Astro.props;
+---
+
+<svg
+  class={className}
+  viewBox="-1 -8 370 66"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label="agentvault"
+>
+  <path d="M0 5H8M0 10H10M0 15H12M0 20H14M0 25H16M0 30H18M0 35H20M2 45H20" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <rect x="23" y="0" width="4" height="50" rx="1" fill="currentColor"/>
+  <path d="M50 5H42M50 10H40M50 15H38M50 20H36M50 25H34M50 30H32M50 35H30M48 45H30" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <text x="65" y="20" fill="currentColor" dominant-baseline="central" style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 54px; font-weight: 400;">agentvault</text>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,18 +6,19 @@ import ProtocolOverview from '../components/sections/ProtocolOverview.astro';
 import VaultFamily from '../components/sections/VaultFamily.astro';
 import LinksResources from '../components/sections/LinksResources.astro';
 import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
-import AVMark from '../components/icons/AVMark.astro';
+import AVLockup from '../components/icons/AVLockup.astro';
+import VCAVMark from '../components/icons/VCAVMark.astro';
 ---
 
 <Layout>
-  <a href="#" class="site-mark" aria-label="AgentVault">
-    <AVMark class="site-mark__icon" />
+  <a href="#" class="site-mark" aria-label="vcav.io">
+    <VCAVMark class="site-mark__icon" />
   </a>
   <main>
     <header class="hero">
       <div class="container">
         <div class="hero__content">
-          <h1 class="hero__title"><AVMark class="hero__mark" />AgentVault</h1>
+          <h1 class="hero__title"><AVLockup class="hero__lockup" /></h1>
           <p class="hero__claim">
             AI agents are becoming delegates.
           </p>
@@ -142,21 +143,13 @@ import AVMark from '../components/icons/AVMark.astro';
   }
 
   .hero__title {
-    display: flex;
-    align-items: center;
-    gap: 0.3em;
-    font-size: clamp(2.5rem, 5vw, 3.5rem);
-    font-weight: 700;
-    letter-spacing: -0.03em;
     color: var(--color-text);
     margin-bottom: var(--space-lg);
   }
 
-  :global(.hero__mark) {
-    height: 0.85em;
+  :global(.hero__lockup) {
+    height: clamp(2.5rem, 5vw, 3.5rem);
     width: auto;
-    flex-shrink: 0;
-    color: var(--color-accent);
   }
 
   .hero__claim {


### PR DESCRIPTION
## Summary
- Hero title uses the full designed SVG lockup (icon + Inter wordmark) instead of icon + DOM text
- Sticky nav mark changed from AV to VCAV — represents the vcav.io org, not the product

## Test plan
- [ ] Hero renders the full lockup at correct responsive size
- [ ] Sticky nav shows VCAV mark (denser paired lines, square caps)
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)