### PR TITLE
Link red team evaluation notes

### DIFF
--- a/src/components/sections/LinksResources.astro
+++ b/src/components/sections/LinksResources.astro
@@ -31,7 +31,12 @@
       </li>
       <li class="resource">
         <span class="resource__label">Red team results</span>
-        <span class="resource__soon">Coming soon</span>
+        <a
+          href="https://github.com/vcav-io/agentvault/blob/main/docs/red-team-evaluation-notes.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="resource__link"
+        >Red team evaluation notes</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- Replace "Coming soon" placeholder for red team results with link to `docs/red-team-evaluation-notes.md` in the AV repo
- Protocol specification remains "Coming soon" — tracked by vcav-io/agentvault#96

## Test plan
- [x] `npm run build` passes
- [ ] Verify link resolves to the correct document on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)