### PR TITLE
Link protocol specification from resources

### DIFF
--- a/src/components/sections/LinksResources.astro
+++ b/src/components/sections/LinksResources.astro
@@ -27,7 +27,12 @@
       </li>
       <li class="resource">
         <span class="resource__label">Protocol specification</span>
-        <span class="resource__soon">Coming soon</span>
+        <a
+          href="https://github.com/vcav-io/agentvault/blob/main/docs/protocol-spec.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="resource__link"
+        >Protocol spec v0.1.0</a>
       </li>
       <li class="resource">
         <span class="resource__label">Red team results</span>


### PR DESCRIPTION
## Summary

- Replaces "Coming soon" placeholder with a link to the published protocol spec
- Links to `docs/protocol-spec.md` in the agentvault repo (merged in vcav-io/agentvault#97)

## Test plan

- [x] Verify link resolves to https://github.com/vcav-io/agentvault/blob/main/docs/protocol-spec.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)