### PR TITLE
fix: improve readability — brighter text, blue accent

### DIFF
--- a/src/components/sections/PositioningText.astro
+++ b/src/components/sections/PositioningText.astro
@@ -65,7 +65,7 @@
   .positioning p {
     font-size: var(--text-base);
     line-height: var(--leading-relaxed);
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     max-width: none;
   }
 

--- a/src/components/sections/WhyThisMatters.astro
+++ b/src/components/sections/WhyThisMatters.astro
@@ -48,7 +48,7 @@
   .why-content p {
     font-size: var(--text-base);
     line-height: var(--leading-relaxed);
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     max-width: none;
   }
 

--- a/src/components/simulation/Simulation.astro
+++ b/src/components/simulation/Simulation.astro
@@ -447,10 +447,10 @@
   .vault-card__step-tag {
     font-size: 10px;
     color: var(--color-accent);
-    background: rgba(90, 180, 192, 0.08);
+    background: rgba(107, 163, 247, 0.08);
     padding: 1px 6px;
     border-radius: 3px;
-    border: 1px solid rgba(90, 180, 192, 0.15);
+    border: 1px solid rgba(107, 163, 247, 0.15);
     white-space: nowrap;
   }
 
@@ -639,7 +639,7 @@
     color: var(--color-accent-bright);
     line-height: 1.7;
     text-align: left;
-    box-shadow: 0 0 30px var(--color-accent-glow), 0 0 60px rgba(90, 180, 192, 0.05);
+    box-shadow: 0 0 30px var(--color-accent-glow), 0 0 60px rgba(107, 163, 247, 0.05);
     white-space: pre;
   }
 
@@ -843,10 +843,10 @@
     .tl-card__tag {
       font-size: 10px;
       color: var(--color-accent);
-      background: rgba(90, 180, 192, 0.08);
+      background: rgba(107, 163, 247, 0.08);
       padding: 1px 6px;
       border-radius: 3px;
-      border: 1px solid rgba(90, 180, 192, 0.15);
+      border: 1px solid rgba(107, 163, 247, 0.15);
       white-space: nowrap;
       flex-shrink: 0;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -220,7 +220,7 @@ import VCAVMark from '../components/icons/VCAVMark.astro';
   .hero__cta:hover {
     color: var(--color-accent-bright);
     border-color: var(--color-accent);
-    background: rgba(90, 180, 192, 0.05);
+    background: rgba(107, 163, 247, 0.05);
   }
 
   .simulation-section {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,14 +9,14 @@
   --color-border: #222238;
   --color-border-subtle: #181828;
 
-  --color-text: #ededeb;
-  --color-text-secondary: #9494a8;
-  --color-text-dim: #5a5a70;
+  --color-text: #f5f5f3;
+  --color-text-secondary: #b8b8cc;
+  --color-text-dim: #78788e;
 
-  --color-accent: #5ab4c0;
-  --color-accent-bright: #7dd4e0;
-  --color-accent-dim: #2a7080;
-  --color-accent-glow: rgba(90, 180, 192, 0.12);
+  --color-accent: #6ba3f7;
+  --color-accent-bright: #93bfff;
+  --color-accent-dim: #3a5a8a;
+  --color-accent-glow: rgba(107, 163, 247, 0.12);
 
   --color-success: #50b070;
   --color-error: #e04848;
@@ -27,7 +27,7 @@
   /* Vault-specific — centre panel trust boundary */
   --color-vault-bg: #0a0e18;
   --color-vault-border: #1a2848;
-  --color-vault-glow: rgba(90, 180, 192, 0.06);
+  --color-vault-glow: rgba(107, 163, 247, 0.06);
 
   /* Typography */
   --font-body: 'Outfit', system-ui, -apple-system, sans-serif;
@@ -56,12 +56,12 @@
   --space-4xl: 5rem;
 
   /* Principal colours — per-agent colour coding */
-  --color-alice: hsl(210, 50%, 68%);
-  --color-alice-dim: hsl(210, 35%, 48%);
+  --color-alice: hsl(210, 50%, 72%);
+  --color-alice-dim: hsl(210, 35%, 52%);
   --color-alice-bg: hsla(210, 50%, 65%, 0.07);
   --color-alice-border: hsla(210, 50%, 65%, 0.18);
-  --color-bob: hsl(35, 55%, 68%);
-  --color-bob-dim: hsl(35, 40%, 48%);
+  --color-bob: hsl(35, 55%, 72%);
+  --color-bob-dim: hsl(35, 40%, 52%);
   --color-bob-bg: hsla(35, 55%, 65%, 0.07);
   --color-bob-border: hsla(35, 55%, 65%, 0.18);
 
@@ -115,7 +115,7 @@ body::before {
   height: 100vh;
   z-index: -1;
   pointer-events: none;
-  background: radial-gradient(ellipse 80% 50% at 50% 0%, rgba(90, 180, 192, 0.04), transparent);
+  background: radial-gradient(ellipse 80% 50% at 50% 0%, rgba(107, 163, 247, 0.04), transparent);
 }
 
 /* Film grain noise — adds depth to flat dark backgrounds */


### PR DESCRIPTION
## Summary
- **Text contrast raised**: primary text near-white (#f5f5f3, ~18:1), secondary text #b8b8cc (~10:1, was ~6.5:1), dim text #78788e (~4.8:1, now meets AA)
- **Accent color replaced**: teal (#5ab4c0, ~4.5:1) → blue (#6ba3f7, ~6.5:1) across all CSS variables and 6 hardcoded rgba values in components
- **Body text promoted**: Positioning and Why This Matters sections now use primary text color instead of secondary — these are core narrative, not metadata
- **Principal colors bumped**: Alice/Bob lightness +4% for consistency

## Test plan
- [ ] Visual inspection: compare before/after screenshots at hero, protocol, why-this-matters, links sections
- [ ] WCAG contrast check: all text/bg combos meet AA (4.5:1 body, 3:1 large)
- [ ] Simulation component renders correctly with new blue accent
- [ ] Hover states on links and CTA buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)