### PR TITLE
fix: hero + vault family readability, VFC link

### DIFF
--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -8,15 +8,15 @@ import VCAVMark from '../icons/VCAVMark.astro';
 <section class="section section--alt reveal" id="family">
   <div class="container">
     <h2>The Vault Family</h2>
-    <p class="intro text-secondary">
+    <p class="intro">
       AgentVault, VCAV, and VFC share a single principle:
     </p>
-    <p class="intro text-secondary principles">
+    <p class="intro principles">
       Bound internal reasoning.<br>
       Bound external disclosure.<br>
       Verifiable enforcement.
     </p>
-    <p class="intro intro--paired text-secondary">
+    <p class="intro intro--paired">
       They differ in assurance level.<br>
       The protocol remains the same.
     </p>
@@ -61,7 +61,12 @@ import VCAVMark from '../icons/VCAVMark.astro';
       <div class="card">
         <div class="card__header">
           <h3 class="card__name">VFC — Vault Family Core</h3>
-          <span class="card__link card__link--muted">vcav-io/vfc — coming soon</span>
+          <a
+            href="https://github.com/vcav-io/vault-family-core"
+            class="card__link"
+            target="_blank"
+            rel="noopener noreferrer"
+          >vcav-io/vault-family-core</a>
         </div>
         <p class="card__description">
           Receipt envelope, cryptographic primitives, AFAL wire types, and

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -62,7 +62,7 @@ import VCAVMark from '../components/icons/VCAVMark.astro';
               Only a structured compatibility signal is emitted.
             </p>
             <p class="sim-module-header__subtitle text-secondary" style="margin-top: var(--space-xs); font-style: italic;">
-              Illustrative walkthrough of a live protocol execution.
+              Illustrative walkthrough of a protocol execution.
             </p>
           </div>
           <div class="sim-module-header__controls">
@@ -155,7 +155,7 @@ import VCAVMark from '../components/icons/VCAVMark.astro';
   .hero__claim {
     font-size: var(--text-xl);
     line-height: var(--leading-normal);
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     max-width: none;
     margin-bottom: var(--space-md);
   }
@@ -176,7 +176,7 @@ import VCAVMark from '../components/icons/VCAVMark.astro';
 
   .hero__guarantees li {
     font-size: var(--text-sm);
-    color: var(--color-accent-dim);
+    color: var(--color-accent);
     padding-left: 1.2em;
     position: relative;
   }
@@ -190,7 +190,7 @@ import VCAVMark from '../components/icons/VCAVMark.astro';
 
   .hero__tagline {
     font-size: var(--text-base);
-    color: var(--color-text-secondary);
+    color: var(--color-text);
     margin-top: var(--space-lg);
     font-style: italic;
   }


### PR DESCRIPTION
## Summary
- Hero section text promoted from secondary grey to primary white
- Guarantees list in accent blue for visual pop
- Vault Family intro text promoted to primary
- VFC card: replaced "coming soon" with live link to vcav-io/vault-family-core
- Removed "live" from simulation subtitle

## Test plan
- [ ] Hero text clearly readable on dark background
- [ ] Blue guarantees list stands out
- [ ] VFC card link works
- [ ] Vault Family intro text readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)