### PR TITLE
content: refine positioning and closing — honest framing

### DIFF
--- a/src/components/sections/PositioningText.astro
+++ b/src/components/sections/PositioningText.astro
@@ -8,8 +8,8 @@
     <div class="positioning">
       <p>
         People already share deeply personal context with AI — health concerns,
-        financial anxieties, private doubts. The next step is inevitable: those
-        agents coordinating directly with each other.
+        financial anxieties, private doubts. The next step is already happening:
+        those agents coordinating directly with each other.
       </p>
       <p>
         The obvious mitigation is to strip agents of context before they coordinate.
@@ -30,11 +30,11 @@
         choosing to withhold.
       </p>
       <p>
-        We built TLS for web traffic. We built enclaves for confidential computation.
-        We built nothing for agent-to-agent reasoning.
-      </p>
-      <p>
-        AgentVault is that primitive.
+        AgentVault is a first attempt at infrastructure for this layer. It addresses
+        the unbounded channel — the open-ended free-text surface where private
+        reasoning leaks by default. The residual channel through structured outputs
+        is narrower and explicit, but not zero. Stronger guarantees require a harder
+        boundary. That is what the rest of the Vault Family is for.
       </p>
     </div>
   </div>

--- a/src/components/sections/WhyThisMatters.astro
+++ b/src/components/sections/WhyThisMatters.astro
@@ -28,8 +28,9 @@
         can and cannot be revealed.
       </p>
       <p>
-        AgentVault defines a coordination layer for delegated AI — analogous to TLS
-        for web traffic, but for bounded reasoning exchange.
+        AgentVault is a first attempt at that coordination layer — designed to make
+        the boundary mechanical rather than social, and verifiable rather than assumed.
+        It is an open research prototype, and scrutiny is welcome.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **PositioningText**: "already happening" replaces "inevitable"; TLS analogy replaced with "first attempt" framing and honest residual-signal acknowledgment
- **WhyThisMatters**: TLS analogy replaced with distinct closing — "open research prototype, and scrutiny is welcome"
- Two sections now have complementary but non-repetitive closings

Companion: vcav-io/agentvault PR for README.

## Test plan
- [x] Copy reviewed for consistency with README
- [ ] Visual check on deployed site

🤖 Generated with [Claude Code](https://claude.com/claude-code)