### PR TITLE
feat: serve site at /agentvault path

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,4 +2,6 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  base: '/agentvault/',
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,7 +23,7 @@ const {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
     <title>{title}</title>
   </head>
   <body>

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "astro",
+  "redirects": [
+    { "source": "/", "destination": "/agentvault", "permanent": false }
+  ],
   "headers": [
     {
       "source": "/fonts/(.*)",


### PR DESCRIPTION
## Summary
- Add `base: '/agentvault/'` to Astro config — all asset paths auto-prefixed
- Add root → /agentvault redirect in vercel.json
- Fix favicon href to use `import.meta.env.BASE_URL`

## Manual steps after merge
1. Squarespace DNS: add CNAME `vcav.io` → `cname.vercel-dns.com`
2. Vercel dashboard: add `vcav.io` as custom domain

## Test plan
- [ ] `npm run build` succeeds
- [ ] Built HTML references `/agentvault/_astro/...` assets
- [ ] Favicon at `/agentvault/favicon.svg`
- [ ] Vercel preview shows site at `/agentvault` path

Generated with [Claude Code](https://claude.com/claude-code)