### PR TITLE
fix: add rewrites to serve site at /agentvault path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,10 @@
   "redirects": [
     { "source": "/", "destination": "/agentvault", "permanent": false }
   ],
+  "rewrites": [
+    { "source": "/agentvault", "destination": "/index.html" },
+    { "source": "/agentvault/(.*)", "destination": "/$1" }
+  ],
   "headers": [
     {
       "source": "/fonts/(.*)",


### PR DESCRIPTION
Astro's base config prefixes asset URLs but doesn't change the output directory. Add Vercel rewrites to map /agentvault/* to the actual build output at root.