### PR TITLE
fix: SVG lockup for site-mark, hidden on mobile (#158)

### DIFF
--- a/src/components/icons/VCAVLockup.astro
+++ b/src/components/icons/VCAVLockup.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  class?: string;
+}
+const { class: className } = Astro.props;
+---
+
+<svg
+  class={className}
+  viewBox="-1 -8 260 66"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+  role="img"
+  aria-label="vcav"
+>
+  <path d="M0 5H8M0 7H8M0 12H10M0 14H10M0 19H12M0 21H12M0 26H14M0 28H14M0 33H16M0 35H16M2 45H18" stroke="currentColor" stroke-width="2" stroke-linecap="square"/>
+  <rect x="21" y="0" width="8" height="50" rx="1" fill="currentColor"/>
+  <path d="M50 5H42M50 7H42M50 12H40M50 14H40M50 19H38M50 21H38M50 26H36M50 28H36M50 33H34M50 35H34M48 45H32" stroke="currentColor" stroke-width="2" stroke-linecap="square"/>
+  <text x="65" y="25" fill="currentColor" dominant-baseline="central" style="font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 54px; font-weight: 700; letter-spacing: 0.1em;">VCAV</text>
+</svg>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,13 +7,12 @@ import VaultFamily from '../components/sections/VaultFamily.astro';
 import LinksResources from '../components/sections/LinksResources.astro';
 import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
 import AVLockup from '../components/icons/AVLockup.astro';
-import VCAVMark from '../components/icons/VCAVMark.astro';
+import VCAVLockup from '../components/icons/VCAVLockup.astro';
 ---
 
 <Layout>
   <a href="https://vcav.io" class="site-mark" aria-label="vcav.io">
-    <VCAVMark class="site-mark__icon" />
-    <span class="site-mark__label">vcav</span>
+    <VCAVLockup class="site-mark__lockup" />
   </a>
   <main>
     <header class="hero">
@@ -136,17 +135,15 @@ import VCAVMark from '../components/icons/VCAVMark.astro';
     opacity: 1;
   }
 
-  :global(.site-mark__icon) {
-    width: 24px;
-    height: 24px;
+  :global(.site-mark__lockup) {
+    height: 20px;
+    width: auto;
   }
 
-  .site-mark__label {
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--color-text-dim);
+  @media (max-width: 767px) {
+    .site-mark {
+      display: none;
+    }
   }
 
   .hero {


### PR DESCRIPTION
## Summary
- Replaces icon + label site-mark with a single `VCAVLockup.astro` component (icon + "VCAV" text baked into SVG)
- Desktop: renders at 20px height, proper lockup
- Mobile (<768px): `display: none` — no logo overlap

Closes #158

## Test plan
- [x] Desktop: VCAV lockup visible at correct size in top-left
- [x] Mobile (375px): lockup hidden entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)