### PR TITLE
feat: SEO Wave 1a — meta tags, OG/Twitter, crawlable H1, hero copy (#33, #34)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -10,15 +10,18 @@ interface Props {
   title?: string;
   description?: string;
   canonicalPath?: string;
+  ogImage?: string;
 }
 
 const {
-  title = 'vcav.io — Bounded Disclosure for AI Agent Coordination',
-  description = 'The Vault Family: cryptographically enforced sessions where AI agents coordinate on sensitive problems under verifiable constraints on information flow.',
+  title = 'AgentVault — Private, Verifiable Coordination for AI Agents',
+  description = 'AgentVault is a protocol for bounded disclosure between AI agents. Coordination contracts constrain what can be disclosed. Schema-bound outputs narrow the channel. Cryptographic receipts prove what governed the session.',
   canonicalPath = '/agentvault/',
+  ogImage = '/agentvault/logos/org-avatar.png',
 } = Astro.props;
 
 const canonicalUrl = `https://vcav.io${canonicalPath}`;
+const ogImageUrl = `https://vcav.io${ogImage}`;
 ---
 
 <!doctype html>
@@ -29,6 +32,15 @@ const canonicalUrl = `https://vcav.io${canonicalPath}`;
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />
     <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}favicon.svg`} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={ogImageUrl} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImageUrl} />
     <title>{title}</title>
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -18,26 +18,20 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
     <header class="hero">
       <div class="container">
         <div class="hero__content">
-          <h1 class="hero__title"><AVLockup class="hero__lockup" /></h1>
+          <AVLockup class="hero__lockup" />
+          <h1 class="hero__title">Private, verifiable coordination for AI agents</h1>
           <p class="hero__claim">
-            AI agents are becoming delegates.
+            AI agents are becoming delegates. When they coordinate, they carry sensitive personal context from their users into the interaction.
           </p>
           <p class="hero__claim hero__claim--sub">
-            We lack infrastructure for private coordination between them.
-          </p>
-          <p class="hero__claim hero__claim--sub">
-            Each agent carries sensitive personal context from its user.<br>
-            When agents coordinate directly, that context becomes part of the interaction surface.
-          </p>
-          <p class="hero__claim hero__claim--sub">
-            AgentVault inserts a mechanical boundary between reasoning and disclosure — enforced at the infrastructure level, not by prompting.
+            AgentVault is a protocol for bounded disclosure — it constrains what agents can reveal to each other and produces a verifiable record of what governed the session.
           </p>
           <ul class="hero__guarantees font-mono">
-            <li>Schema-enforced outputs — the channel is structurally narrowed, not just instructed</li>
-            <li>Cryptographic receipts — signed proof of exactly what governed the session</li>
-            <li>Content-addressed contracts — immutable, versioned execution context</li>
+            <li>Coordination contracts — agents agree on purpose, terms, and output structure before any context is shared</li>
+            <li>Schema-bound outputs — the relay enforces a bounded signal, not free-text exchange</li>
+            <li>Cryptographic receipts — signed proof of exactly which contract, schema, and policy governed the session</li>
           </ul>
-          <p class="hero__tagline">A coordination primitive for bounded disclosure.</p>
+          <p class="hero__tagline">Not just interoperability — bounded disclosure.</p>
           <div class="hero__ctas">
             <a href="https://github.com/vcav-io/agentvault" class="hero__cta" target="_blank" rel="noopener noreferrer">View on GitHub</a>
             <a href="#protocol" class="hero__cta">Read the Protocol</a>
@@ -156,18 +150,22 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
     margin: 0 auto;
   }
 
+  :global(.hero__lockup) {
+    height: clamp(2.5rem, 5vw, 3.5rem);
+    width: auto;
+    margin-bottom: var(--space-md);
+  }
+
   .hero__title {
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    line-height: var(--leading-tight);
     color: var(--color-text);
     margin-bottom: var(--space-lg);
   }
 
-  :global(.hero__lockup) {
-    height: clamp(2.5rem, 5vw, 3.5rem);
-    width: auto;
-  }
-
   .hero__claim {
-    font-size: var(--text-xl);
+    font-size: var(--text-base);
     line-height: var(--leading-normal);
     color: var(--color-text);
     max-width: none;


### PR DESCRIPTION
## Summary

Addresses the two most impactful Phase 1 SEO items: meta/social tags and hero section copy.

### Meta & social (#33)
- **Title**: "AgentVault — Private, Verifiable Coordination for AI Agents"
- **Meta description**: AgentVault-focused, hits primary keywords (bounded disclosure, coordination contracts, schema-bound outputs, cryptographic receipts)
- **OG tags**: type, url, title, description, image (org-avatar.png)
- **Twitter card**: summary card with title, description, image
- Layout props are extensible for future concept pages (`canonicalPath`, `ogImage`)

### H1 & hero copy (#34)
- **H1**: Crawlable text "Private, verifiable coordination for AI agents" (was SVG-only)
- SVG lockup remains as visual brand element above the H1
- Hero copy revised to use search-friendly language throughout
- Mechanism bullets reframed: coordination contracts → schema-bound outputs → cryptographic receipts
- Tagline: "Not just interoperability — bounded disclosure."

Closes #33, closes #34

## Before/after

| Signal | Before | After |
|--------|--------|-------|
| Title | "vcav.io — Bounded Disclosure..." | "AgentVault — Private, Verifiable..." |
| Description | "The Vault Family: cryptographically..." | "AgentVault is a protocol for bounded disclosure..." |
| H1 text | "agentvault" (SVG alt text only) | "Private, verifiable coordination for AI agents" |
| OG tags | None | Full set |
| Twitter card | None | Summary card |

## Test plan
- [x] Build succeeds
- [x] Desktop: SVG lockup + text H1 renders correctly
- [x] Mobile: layout clean, VCAV logo hidden
- [x] Meta tags verified via JS evaluation on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)