### PR TITLE
feat: SEO Wave 1c — FAQ with JSON-LD + Assurance Levels rewrite

### DIFF
--- a/src/components/sections/FAQ.astro
+++ b/src/components/sections/FAQ.astro
@@ -1,0 +1,98 @@
+---
+// FAQ.astro
+// Search-friendly FAQ with JSON-LD structured data
+
+const faqs = [
+  {
+    question: 'What is agent-to-agent privacy?',
+    answer: 'When AI agents act as delegates, they carry sensitive personal context from their users — health concerns, financial details, private preferences. Agent-to-agent privacy is the problem of preventing that context from leaking when agents coordinate with each other. It is a disclosure-boundary problem: not whether agents can communicate, but how much they reveal when they do.',
+  },
+  {
+    question: 'How can AI agents coordinate without leaking private context?',
+    answer: 'AgentVault replaces open-ended free-text communication with a structured coordination protocol. Both agents agree to a coordination contract that defines the session\'s purpose and output schema. The relay enforces those constraints — validating every output against the schema and rejecting anything outside the agreed bounds. The result is a bounded signal, not a free-text exchange.',
+  },
+  {
+    question: 'What is a coordination contract?',
+    answer: 'A coordination contract is the machine-readable agreement that governs an AgentVault session. It defines the purpose of the coordination, the allowed output structure (as a JSON Schema), and the terms both agents consent to. Contracts are content-addressed — referenced by their SHA-256 hash — and established before any private context is shared. They are never renegotiated mid-session.',
+  },
+  {
+    question: 'What is a bounded signal?',
+    answer: 'A bounded signal is the output of an AgentVault session: a compressed, schema-constrained result produced under a fixed contract. Unlike free-text communication between agents, a bounded signal carries only what the output schema permits. The relay enforces this structurally — invalid outputs are rejected and never returned to either party.',
+  },
+  {
+    question: 'How is AgentVault different from ordinary agent interoperability?',
+    answer: 'Agent interoperability protocols make communication between agents possible. AgentVault constrains what may be disclosed during that communication and produces a verifiable record of what governed the session. It is not a transport layer or a discovery mechanism — it is a disclosure-boundary layer that sits on top of existing agent infrastructure.',
+  },
+];
+
+const faqJsonLd = JSON.stringify({
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  'mainEntity': faqs.map((faq) => ({
+    '@type': 'Question',
+    'name': faq.question,
+    'acceptedAnswer': {
+      '@type': 'Answer',
+      'text': faq.answer,
+    },
+  })),
+});
+---
+
+<section class="section reveal" id="faq">
+  <div class="container">
+    <div class="faq">
+      <h2 class="faq__title">Frequently Asked Questions</h2>
+      <dl class="faq__list">
+        {faqs.map((faq) => (
+          <div class="faq__item">
+            <dt class="faq__question">{faq.question}</dt>
+            <dd class="faq__answer">{faq.answer}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  </div>
+</section>
+
+<script type="application/ld+json" set:html={faqJsonLd} />
+
+<style>
+  .faq {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .faq__title {
+    margin-bottom: var(--space-xl);
+  }
+
+  .faq__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-lg);
+  }
+
+  .faq__item {
+    padding-bottom: var(--space-lg);
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+
+  .faq__item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+  }
+
+  .faq__question {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-sm);
+  }
+
+  .faq__answer {
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
+  }
+</style>

--- a/src/components/sections/VaultFamily.astro
+++ b/src/components/sections/VaultFamily.astro
@@ -7,18 +7,16 @@ import VCAVMark from '../icons/VCAVMark.astro';
 
 <section class="section section--alt reveal" id="family">
   <div class="container">
-    <h2>The Vault Family</h2>
+    <h2>Assurance Levels</h2>
     <p class="intro">
-      AgentVault, VCAV, and VFC share a single principle:
-    </p>
-    <p class="intro principles">
-      Bound internal reasoning.<br>
-      Bound external disclosure.<br>
-      Verifiable enforcement.
+      AgentVault assumes you already trust your AI model provider — most
+      consumers do. That assumption makes the protocol lightweight and
+      general. VCAV removes even the provider from the trust envelope,
+      using local models and hardware attestation.
     </p>
     <p class="intro intro--paired">
-      They differ in assurance level.<br>
-      The protocol remains the same.
+      Same bounded-disclosure principle.<br>
+      The trust envelope shrinks as the stakes rise.
     </p>
 
     <div class="cards">
@@ -36,11 +34,12 @@ import VCAVMark from '../icons/VCAVMark.astro';
           >vcav-io/agentvault</a>
         </div>
         <p class="card__description">
-          The open protocol for bounded agent-to-agent coordination.
-          Runs in a software execution lane. Designed to be embedded inside agent
-          frameworks — not replace them.
+          The open protocol for private, verifiable agent-to-agent coordination.
+          Two execution lanes: a software lane (operator-attested) and a TEE lane
+          (hardware-assured, operator excluded from plaintext). Relay-enforced
+          contracts, schema-bound outputs, and cryptographic receipts.
         </p>
-        <div class="card__tag card__tag--primary">Open coordination layer</div>
+        <div class="card__tag card__tag--primary">Software + TEE execution lanes</div>
       </div>
 
       <div class="card card--muted">
@@ -52,10 +51,13 @@ import VCAVMark from '../icons/VCAVMark.astro';
           <span class="card__badge">Private — in development</span>
         </div>
         <p class="card__description">
-          Hardware-backed boundary with stronger isolation guarantees.
-          Same protocol. Higher assurance context.
+          The highest assurance tier — local models, hardware attestation
+          (AMD SEV-SNP), and side-channel hardening shrink the trust envelope
+          to the sealed VM itself. A dedicated orchestrator enforces information
+          flow control and privacy budgets. Same bounded-disclosure principle,
+          strongest guarantees.
         </p>
-        <div class="card__tag">Sealed execution lane</div>
+        <div class="card__tag">Confidential coordination infrastructure</div>
       </div>
 
       <div class="card">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import ProtocolOverview from '../components/sections/ProtocolOverview.astro';
 import VaultFamily from '../components/sections/VaultFamily.astro';
 import LinksResources from '../components/sections/LinksResources.astro';
 import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
+import FAQ from '../components/sections/FAQ.astro';
 import AVLockup from '../components/icons/AVLockup.astro';
 import VCAVLockup from '../components/icons/VCAVLockup.astro';
 ---
@@ -101,6 +102,7 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
 
     <ProtocolOverview />
     <WhyThisMatters />
+    <FAQ />
     <VaultFamily />
     <LinksResources />
 


### PR DESCRIPTION
## Summary
- Add FAQ section with 5 search-targeted questions and FAQPage JSON-LD structured data
- Rename "The Vault Family" → "Assurance Levels" with architecture-accurate intro and card copy
- AgentVault card now mentions both execution lanes (software + TEE)
- VCAV card updated: highest assurance tier — local model, hardware attestation, side-channel hardening

Closes #37, closes #38

## Test plan
- [ ] Verify FAQ renders correctly with proper spacing
- [ ] Validate JSON-LD output in built HTML (`dist/agentvault/index.html`)
- [ ] Check "Assurance Levels" section card copy is accurate
- [ ] Test responsive layout on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)