### PR TITLE
feat: SEO Phase 2 — concept pages for ownable terms

### DIFF
--- a/src/components/ConceptPage.astro
+++ b/src/components/ConceptPage.astro
@@ -1,0 +1,341 @@
+---
+import AVMark from './icons/AVMark.astro';
+
+interface Props {
+  title: string;
+  subtitle: string;
+  currentSlug: string;
+}
+
+const { title, subtitle, currentSlug } = Astro.props;
+const base = import.meta.env.BASE_URL;
+
+const concepts = [
+  { slug: 'agent-to-agent-privacy', label: 'Agent-to-Agent Privacy', brief: 'Why privacy is the missing layer in agent interoperability' },
+  { slug: 'bounded-disclosure', label: 'Bounded Disclosure', brief: 'Constraining what agents can reveal during coordination' },
+  { slug: 'coordination-contracts', label: 'Coordination Contracts', brief: 'Machine-readable agreements that govern agent sessions' },
+  { slug: 'bounded-signals', label: 'Bounded Signals', brief: 'Schema-constrained outputs instead of free-text exchange' },
+  { slug: 'cryptographic-receipts', label: 'Cryptographic Receipts', brief: 'Signed proof of what governed the coordination session' },
+];
+
+const relatedConcepts = concepts.filter(c => c.slug !== currentSlug);
+---
+
+<nav class="top-bar">
+  <div class="container top-bar__inner">
+    <a href={base} class="top-bar__home" aria-label="AgentVault home">
+      <AVMark class="top-bar__mark" />
+      <span class="top-bar__name font-mono">AgentVault</span>
+    </a>
+    <a href={base} class="top-bar__back font-mono">&larr; Overview</a>
+  </div>
+</nav>
+
+<header class="concept-header">
+  <div class="container">
+    <div class="concept-header__inner">
+      <h1 class="concept-header__title">{title}</h1>
+      <p class="concept-header__subtitle">{subtitle}</p>
+    </div>
+  </div>
+</header>
+
+<article class="concept-body">
+  <div class="container">
+    <div class="concept-body__prose">
+      <slot />
+    </div>
+  </div>
+</article>
+
+<section class="concept-explore section--alt">
+  <div class="container">
+    <div class="concept-explore__inner">
+      <h2 class="concept-explore__title">Explore the implementation</h2>
+      <ul class="concept-explore__links">
+        <li><a href="https://github.com/vcav-io/agentvault" target="_blank" rel="noopener noreferrer">GitHub repository</a></li>
+        <li><a href="https://github.com/vcav-io/agentvault/blob/main/docs/protocol.md" target="_blank" rel="noopener noreferrer">Protocol specification</a></li>
+        <li><a href="https://github.com/vcav-io/agentvault/blob/main/docs/getting-started.md" target="_blank" rel="noopener noreferrer">Run the demo</a></li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<nav class="related-concepts section" aria-label="Related concepts">
+  <div class="container">
+    <div class="related-concepts__inner">
+      <h2 class="related-concepts__title">Related Concepts</h2>
+      <div class="related-concepts__grid">
+        {relatedConcepts.map(c => (
+          <a href={`${base}${c.slug}/`} class="related-card">
+            <span class="related-card__label font-mono">{c.label}</span>
+            <span class="related-card__brief">{c.brief}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  </div>
+</nav>
+
+<footer class="site-footer">
+  <div class="container">
+    <p class="text-dim" style="font-size: var(--text-sm);">
+      vcav.io · <a href="mailto:contact@vcav.io" class="footer-link">contact@vcav.io</a>
+    </p>
+  </div>
+</footer>
+
+<style>
+  .top-bar {
+    padding: var(--space-md) 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+
+  .top-bar__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .top-bar__home {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    color: var(--color-text);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .top-bar__home:hover {
+    color: var(--color-accent);
+  }
+
+  :global(.top-bar__mark) {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
+
+  .top-bar__name {
+    font-size: var(--text-sm);
+    font-weight: 500;
+  }
+
+  .top-bar__back {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .top-bar__back:hover {
+    color: var(--color-accent);
+  }
+
+  .concept-header {
+    padding: var(--space-2xl) 0 var(--space-xl);
+  }
+
+  .concept-header__inner {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .concept-header__title {
+    font-size: var(--text-2xl);
+    font-weight: 600;
+    line-height: var(--leading-tight);
+    color: var(--color-text);
+    margin-bottom: var(--space-sm);
+  }
+
+  .concept-header__subtitle {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
+  }
+
+  .concept-body {
+    padding-bottom: var(--space-2xl);
+  }
+
+  .concept-body__prose {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .concept-body__prose :global(h2) {
+    font-size: var(--text-xl);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-top: var(--space-xl);
+    margin-bottom: var(--space-md);
+  }
+
+  .concept-body__prose :global(h2:first-child) {
+    margin-top: 0;
+  }
+
+  .concept-body__prose :global(p) {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+    max-width: none;
+  }
+
+  .concept-body__prose :global(p + p) {
+    margin-top: var(--space-md);
+  }
+
+  .concept-body__prose :global(p + h2) {
+    margin-top: var(--space-xl);
+  }
+
+  .concept-body__prose :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    color: var(--color-accent);
+    background: var(--color-bg-elevated);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+
+  .concept-body__prose :global(strong) {
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .concept-body__prose :global(a) {
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .concept-body__prose :global(a:hover) {
+    color: var(--color-accent-bright);
+  }
+
+  .concept-body__prose :global(ul),
+  .concept-body__prose :global(ol) {
+    margin-top: var(--space-sm);
+    margin-bottom: var(--space-sm);
+    padding-left: 1.5em;
+  }
+
+  .concept-body__prose :global(li) {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+    margin-bottom: var(--space-xs);
+  }
+
+  .concept-explore {
+    padding: var(--space-xl) 0;
+    border-top: 1px solid var(--color-border-subtle);
+  }
+
+  .concept-explore__inner {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .concept-explore__title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-md);
+  }
+
+  .concept-explore__links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md);
+    padding: 0;
+  }
+
+  .concept-explore__links a {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .concept-explore__links a:hover {
+    color: var(--color-accent-bright);
+  }
+
+  .related-concepts {
+    padding: var(--space-2xl) 0;
+  }
+
+  .related-concepts__inner {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .related-concepts__title {
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: var(--space-lg);
+  }
+
+  .related-concepts__grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-md);
+  }
+
+  .related-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-md);
+    background: var(--color-bg-panel);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    text-decoration: none;
+    transition: border-color var(--duration-fast) var(--ease-out),
+                transform 300ms var(--ease-out);
+  }
+
+  .related-card:hover {
+    border-color: var(--color-accent-dim);
+    transform: translateY(-1px);
+  }
+
+  .related-card__label {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  .related-card__brief {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    line-height: var(--leading-relaxed);
+  }
+
+  @media (max-width: 639px) {
+    .related-concepts__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .site-footer {
+    padding: var(--space-2xl) 0;
+    border-top: 1px solid var(--color-border-subtle);
+  }
+
+  .footer-link {
+    color: var(--color-text-dim);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .footer-link:hover {
+    color: var(--color-accent);
+  }
+</style>

--- a/src/components/sections/CoreConcepts.astro
+++ b/src/components/sections/CoreConcepts.astro
@@ -15,6 +15,7 @@
             purpose, the allowed output schema, and the terms both agents consent to.
             Established before any private context is shared. Referenced by hash — never
             renegotiated mid-session.
+            <a href={`${import.meta.env.BASE_URL}coordination-contracts/`} class="concept-card__link">Learn more &rarr;</a>
           </dd>
         </div>
         <div class="concept-card">
@@ -23,6 +24,7 @@
             The session output: a compressed, schema-constrained signal produced under
             a fixed contract. Not free text — a structurally narrowed result that carries
             only what the schema permits. The relay rejects anything outside the agreed bounds.
+            <a href={`${import.meta.env.BASE_URL}bounded-signals/`} class="concept-card__link">Learn more &rarr;</a>
           </dd>
         </div>
         <div class="concept-card">
@@ -31,6 +33,7 @@
             An Ed25519-signed record that binds the contract hash, output schema, prompt
             template, guardian policy, model identity, and relay build to the session result.
             Tamper-evident and independently verifiable by both parties.
+            <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`} class="concept-card__link">Learn more &rarr;</a>
           </dd>
         </div>
         <div class="concept-card">
@@ -39,6 +42,7 @@
             The enforcement mechanism: the relay validates every output against a JSON Schema
             defined in the coordination contract. Invalid outputs are rejected and never
             returned to either party. The channel is structurally narrowed, not just instructed.
+            <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`} class="concept-card__link">Learn more &rarr;</a>
           </dd>
         </div>
       </dl>
@@ -81,6 +85,20 @@
     font-size: var(--text-sm);
     line-height: var(--leading-relaxed);
     color: var(--color-text-secondary);
+  }
+
+  .concept-card__link {
+    display: inline-block;
+    margin-top: var(--space-sm);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .concept-card__link:hover {
+    color: var(--color-accent-bright);
   }
 
   @media (max-width: 639px) {

--- a/src/pages/agent-to-agent-privacy.astro
+++ b/src/pages/agent-to-agent-privacy.astro
@@ -1,0 +1,118 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ConceptPage from '../components/ConceptPage.astro';
+---
+
+<Layout
+  title="Agent-to-Agent Privacy — AgentVault"
+  description="Agent-to-agent privacy is the problem of preventing sensitive personal context from leaking when AI agents coordinate. AgentVault provides the missing disclosure-boundary layer."
+  canonicalPath="/agentvault/agent-to-agent-privacy/"
+>
+  <ConceptPage
+    title="Agent-to-Agent Privacy"
+    subtitle="Why privacy is the missing layer in agent interoperability."
+    currentSlug="agent-to-agent-privacy"
+  >
+    <h2>What is agent-to-agent privacy?</h2>
+
+    <p>
+      Agent-to-agent privacy is the problem of preventing sensitive personal context from leaking when AI agents coordinate on behalf of their users. It is not about whether agents can communicate — it is about how much they reveal when they do.
+    </p>
+
+    <p>
+      When AI agents act as delegates, they carry rich private context. A health agent knows about diagnoses, medications, and symptoms. A financial agent knows about income, debt, and spending patterns. A personal assistant knows about relationship dynamics, emotional state, and private preferences. This context is what makes agents useful — it allows them to act with nuance and relevance on a user's behalf.
+    </p>
+
+    <p>
+      But when these agents need to coordinate with each other — to mediate between two parties, assess compatibility, negotiate terms, or synthesize information across domains — that private context is suddenly at risk. An agent that coordinates with another agent may disclose far more than its user intended, simply because the communication channel permits it.
+    </p>
+
+    <p>
+      Agent-to-agent privacy is, at its core, a disclosure-boundary problem. The question is not whether the connection is secure. The question is whether the structure of the coordination itself limits what can flow between the parties. Without that structural constraint, privacy depends entirely on the discretion of the model — and model discretion is not a privacy guarantee.
+    </p>
+
+    <h2>Why transport security is not enough</h2>
+
+    <p>
+      Most agent interoperability protocols focus on the transport layer. They solve real problems: how do agents discover each other, how do they authenticate, how do they establish a session, how do they exchange messages in a standard format. These are necessary foundations, and protocols like the Model Context Protocol and emerging agent-to-agent standards do important work here.
+    </p>
+
+    <p>
+      Transport security — TLS encryption, mutual authentication, authorization tokens — protects against external threats. It ensures that an eavesdropper on the network cannot read the messages flowing between agents. This is essential, but it addresses only one dimension of the privacy problem.
+    </p>
+
+    <p>
+      Transport security does nothing about what the agents themselves disclose to each other during the session. An agent with access to a user's complete medical history can transmit that history in full over a perfectly encrypted channel. The encryption protects the content from outsiders, but it places no constraint on what the agent chooses to share with its counterpart.
+    </p>
+
+    <p>
+      Consider two agents coordinating to assess whether their users might be compatible roommates. Each agent has access to detailed personal information — work schedule, cleanliness habits, noise sensitivity, financial situation, mental health history. Over a free-text channel, even with strong encryption, either agent could disclose any or all of this context. The threat is not the wire. The threat is the <strong>channel capacity</strong> of the communication itself — the total amount of information the channel's structure permits to flow.
+    </p>
+
+    <p>
+      Privacy in agent-to-agent coordination requires structural constraints on what can flow between agents, not just protection of the pipe. This is fundamentally different from traditional user privacy concerns like GDPR compliance or data-protection regulations. Those frameworks govern how organizations collect, store, and process personal data. Agent-to-agent privacy governs what is disclosed during a live coordination session between autonomous software delegates. It is a coordination-level problem, and it requires a coordination-level solution.
+    </p>
+
+    <h2>How AgentVault addresses agent-to-agent privacy</h2>
+
+    <p>
+      <a href={import.meta.env.BASE_URL}>AgentVault</a> replaces open-ended free-text communication between agents with a structured coordination protocol designed around disclosure boundaries. The core mechanism is simple: instead of letting agents talk freely and hoping they are discreet, the protocol constrains the channel itself so that only a bounded amount of information can pass through it.
+    </p>
+
+    <p>
+      Before any private context is shared, both agents agree to a <strong>coordination contract</strong> — a machine-readable document that defines the session's purpose, the output schema, the prompt template, the guardian policy, and the disclosure terms. The contract is content-addressed, referenced by its SHA-256 hash, and established before the session begins. It is never renegotiated mid-session. Both parties know exactly what they are agreeing to before any private information enters the system.
+    </p>
+
+    <p>
+      During the session, the relay enforces the contract's output schema using JSON Schema validation. The schema defines the exact structure and range of the permitted output — for example, a compatibility score between 1 and 5 with a fixed set of categorical labels. Any output that falls outside the agreed schema is rejected by the relay and never returned to either party. The model may attempt to encode private information in its output, but the schema constrains the expressible range. A field that accepts an integer between 1 and 5 can carry at most ~2.3 bits of information, regardless of how much context the model had access to.
+    </p>
+
+    <p>
+      The result is a <strong>bounded signal</strong> — a compressed, schema-constrained output that carries only what the schema permits. The signal is useful (it answers the coordination question) but structurally limited (it cannot leak arbitrary private context). The privacy guarantee comes not from the model's behavior but from the information-theoretic properties of the output channel.
+    </p>
+
+    <p>
+      After the session completes, both parties receive a <strong>cryptographic receipt</strong> — an Ed25519-signed record that binds the contract hash, output schema, prompt template, guardian policy, model identity, and session metadata to the result. The receipt is independently verifiable. It provides after-the-fact assurance that the session was conducted under the agreed terms, that the output conformed to the declared schema, and that no undisclosed modification occurred between the relay and the parties.
+    </p>
+
+    <p>
+      This is not a privacy-preserving computation in the cryptographic sense. It is not multi-party computation, homomorphic encryption, or differential privacy. Those techniques have their own strengths and trade-offs. AgentVault takes a different approach: <strong>structural enforcement</strong>. The channel is narrowed by design so that disclosure is bounded regardless of model behavior. The model processes private context to produce the output, but the output itself is constrained to a schema that limits how much information it can carry.
+    </p>
+
+    <p>
+      The key insight is that privacy is not achieved by trusting the model to be discreet. Models are opaque, probabilistic systems that may leak information in subtle ways — through word choice, hedging patterns, or statistical correlations in free text. Structural enforcement sidesteps this problem entirely. Even a careless or adversarial model cannot disclose more than the schema permits, because the relay rejects anything outside the schema boundary before it reaches the other party.
+    </p>
+
+    <h2>How agent-to-agent privacy connects to other concepts</h2>
+
+    <p>
+      Agent-to-agent privacy is the problem statement. <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>Bounded disclosure</a> is the principle that addresses it — the idea that coordination between agents should reveal only a bounded amount of information, determined by the structure of the output channel rather than by model behavior.
+    </p>
+
+    <p>
+      The mechanism that enforces bounded disclosure is the <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a>. The contract defines what is permitted before the session begins, making the disclosure boundary explicit, auditable, and immutable for the session's duration.
+    </p>
+
+    <p>
+      The output model is the <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signal</a> — the schema-constrained result that carries the coordination outcome within the declared information-theoretic bounds. Bounded signals are what make the privacy guarantee concrete and measurable rather than aspirational.
+    </p>
+
+    <p>
+      The assurance layer is the <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipt</a>. Receipts provide verifiable proof that the session was conducted under the agreed contract, that the output conformed to the declared schema, and that the privacy bounds were enforced. Without receipts, parties must trust the relay's behavior. With receipts, they can verify it.
+    </p>
+
+    <p>
+      Together, these components form a complete disclosure-boundary architecture — from problem definition through principle, mechanism, output model, and assurance.
+    </p>
+
+    <h2>Key takeaway</h2>
+
+    <p>
+      Agent interoperability makes coordination possible. Agent-to-agent privacy makes it safe. As AI agents become more capable and more deeply integrated into personal and professional life, the amount of sensitive context they carry will only grow. Without structural privacy guarantees at the coordination layer, every agent-to-agent interaction is a potential disclosure event.
+    </p>
+
+    <p>
+      The missing layer is not better encryption or smarter models. It is structural constraints on what agents can disclose during coordination — constraints that hold regardless of model behavior, that are agreed before private context enters the system, and that are cryptographically verifiable after the fact. <a href={import.meta.env.BASE_URL}>AgentVault</a> provides that layer.
+    </p>
+  </ConceptPage>
+</Layout>

--- a/src/pages/bounded-disclosure.astro
+++ b/src/pages/bounded-disclosure.astro
@@ -1,0 +1,112 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ConceptPage from '../components/ConceptPage.astro';
+---
+
+<Layout
+  title="Bounded Disclosure for AI Agents — AgentVault"
+  description="Bounded disclosure constrains what AI agents can reveal during coordination. Learn how contracts, schemas, and relay enforcement create a structurally narrowed channel."
+  canonicalPath="/agentvault/bounded-disclosure/"
+>
+  <ConceptPage
+    title="Bounded Disclosure for AI Agents"
+    subtitle="Constraining what agents can reveal during coordination — not just whether they can communicate."
+    currentSlug="bounded-disclosure"
+  >
+    <h2>What is bounded disclosure?</h2>
+
+    <p>
+      Bounded disclosure is the principle that coordination between AI agents should reveal only what is necessary for the task, and no more. It is the umbrella concept behind <a href={import.meta.env.BASE_URL}>AgentVault</a> — the idea that shapes every layer of the protocol, from session negotiation to receipt verification.
+    </p>
+
+    <p>
+      Bounded disclosure is not about preventing communication. Agents need to coordinate — that is the whole point. It is about constraining <strong>how much information flows through the communication channel</strong> when they do. When two agents coordinate on a sensitive matter — mediation between disputing parties, a compatibility assessment, a negotiation — each agent carries rich private context from its user. That context might include financial details, relationship history, strategic priorities, health information, or legal positions. The agent needs this context to act effectively on behalf of its user. But the other party's agent does not need all of it, and the other party certainly should not receive it.
+    </p>
+
+    <p>
+      Bounded disclosure means the output of that coordination is <strong>structurally narrowed</strong> — compressed into a schema-constrained signal rather than transmitted as free text. The term describes both a design principle and a concrete enforcement mechanism. In AgentVault, bounded disclosure is achieved through four layers working together: <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contracts</a> define the session's bounds, JSON Schema constrains the output structure, relay enforcement rejects anything outside those bounds, and <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipts</a> prove what governed the session. These layers are not aspirational — they are enforced at the infrastructure level.
+    </p>
+
+    <h2>The channel capacity problem</h2>
+
+    <p>
+      Most approaches to AI privacy rely on instructing the model to be careful. System prompts say "don't share sensitive information" or "respect user privacy." Fine-tuning reinforces cooperative behaviour. Guardrails filter outputs for known categories of sensitive data. These are all prompt-level or model-level constraints. They depend entirely on the model following instructions reliably, consistently, and adversarially — which is precisely the property that no current model can guarantee.
+    </p>
+
+    <p>
+      The fundamental problem is <strong>channel capacity</strong>. If the communication channel between two agents permits free text, the channel has enough capacity to carry any information, regardless of what instructions govern the model producing that text. A free-text channel between two agents is like an open pipe — you can ask the model to be careful about what flows through it, but the pipe itself is unconstrained. A sufficiently capable model, whether through adversarial prompting, capability overhang, or simple instruction-following failure, can encode arbitrary information in free-text output. The instruction says "be careful." The channel says "anything goes." When these conflict, the channel wins.
+    </p>
+
+    <p>
+      Bounded disclosure addresses this at the <strong>channel level</strong>, not the instruction level. By replacing free text with a schema-constrained output, the channel capacity itself is reduced. The pipe is physically narrowed. The output must conform to a JSON Schema that defines exactly which fields exist, what values are permitted, and what structure is required. The relay validates every output against the schema before delivery. An output that does not conform is rejected — it never reaches the other party. Even a perfectly adversarial model cannot disclose more than the schema permits, because the enforcement point is outside the model's control.
+    </p>
+
+    <p>
+      This is the difference between asking someone to whisper in a room with open doors and giving them a form with fixed fields to fill out. The whisper depends on cooperation. The form constrains the channel structurally. Channel capacity is not a metaphor in AgentVault — it is a <strong>measurable, computable property</strong> of the output schema. The schema's structural entropy defines the upper bound of information that can flow through the channel. AgentVault quantifies this and includes it in the session receipt, so both parties can verify exactly how much disclosure the channel permitted.
+    </p>
+
+    <h2>The four enforcement layers</h2>
+
+    <p>
+      AgentVault implements bounded disclosure through four layers, each addressing a different failure mode. No single layer is sufficient on its own. Together, they create a defence-in-depth architecture where each layer compensates for the limitations of the others.
+    </p>
+
+    <p>
+      <strong>Layer 1: Coordination contracts.</strong> Before any private context is shared, both agents agree to a <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a> that defines the session's purpose, the allowed output structure, the prompt template, and the guardian policy. The contract is content-addressed — referenced by its SHA-256 hash — and immutable for the session duration. Neither party can change the terms mid-session. The contract prevents scope creep: even if both models are cooperative, the session cannot drift beyond its declared purpose because the contract is locked at session initiation.
+    </p>
+
+    <p>
+      <strong>Layer 2: Schema-bound outputs.</strong> The output schema embedded in the contract is a JSON Schema that defines exactly what the coordination result may contain. This is the mechanism that narrows the channel. A schema permitting only an enum field with three values (<code>"compatible"</code>, <code>"incompatible"</code>, <code>"partially_compatible"</code>) has far less channel capacity than a free-text field. The schema is not advisory — it is the structural constraint that bounds what can be disclosed. Schema design is where the privacy properties of a coordination session are primarily determined. A well-designed schema carries exactly the <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signal</a> the task requires and nothing more.
+    </p>
+
+    <p>
+      <strong>Layer 3: Relay enforcement.</strong> The relay validates every output against the schema. Outputs that fail validation are rejected and never delivered to either party. The relay is not a passive message router — it is a structural enforcement point. It checks that the output conforms to the declared schema, that the session has not exceeded its time bounds, and that the guardian policy has not triggered an abort. The relay cannot see inside TEE-executed sessions, but it can enforce structural properties of the session lifecycle. In the software execution lane, the relay is the entity that ensures bounded disclosure is not merely declared but enforced.
+    </p>
+
+    <p>
+      <strong>Layer 4: Cryptographic receipts.</strong> After the session completes, both parties receive a signed <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipt</a> that binds the contract hash, output schema, prompt template hash, guardian policy hash, model identity, relay build identity, and channel capacity measurement to the session result. The receipt is independently verifiable — either party can check that the session was governed by the contract they agreed to, with the schema they expected, producing a result within the declared bounds. Receipts address the after-the-fact verification problem: even if everything worked correctly during the session, both parties need proof of what governed it.
+    </p>
+
+    <p>
+      These layers are not redundant — they are complementary. Contracts prevent scope creep. Schemas constrain capacity. Relay enforcement prevents bypass. Receipts provide auditability. Remove any one layer and the system has a gap that the remaining layers cannot fully cover.
+    </p>
+
+    <h2>Bounded disclosure vs. privacy-preserving computation</h2>
+
+    <p>
+      Privacy-preserving computation — multi-party computation, homomorphic encryption, differential privacy — aims to compute on data without revealing inputs to the computing party. These are powerful techniques, and they solve a different problem than bounded disclosure. MPC lets two parties compute a joint function without either party seeing the other's inputs. Homomorphic encryption lets a server compute on encrypted data without decrypting it. Differential privacy adds calibrated noise to outputs to prevent reconstruction of individual inputs.
+    </p>
+
+    <p>
+      Bounded disclosure takes a different approach. It constrains what the <strong>output channel</strong> can carry, rather than hiding the inputs during computation. In AgentVault's software execution lane, the model provider sees the private context during processing — the model needs the context to reason effectively. Bounded disclosure does not hide inputs from the model. What it guarantees is that the output — what flows between the two parties — is structurally narrowed to only what the coordination task requires.
+    </p>
+
+    <p>
+      For higher assurance, AgentVault provides a <strong>TEE execution lane</strong> that removes the relay operator from the trust envelope. Using confidential virtual machines with hardware attestation, the TEE lane ensures that even the infrastructure operator cannot observe plaintext context during processing. The trust boundary shrinks to the hardware and the attested code running inside it. And <strong>VCAV</strong>, the highest assurance tier, removes the model provider entirely — using local models running inside attested hardware with side-channel hardening, so that no external party sees the private context at any point. Bounded disclosure is the unifying principle across all three tiers. What changes between tiers is not the principle but the trust envelope — who must be trusted, and what hardware or cryptographic guarantees replace that trust.
+    </p>
+
+    <h2>How bounded disclosure connects to other concepts</h2>
+
+    <p>
+      Bounded disclosure is the overarching principle in AgentVault's architecture. It connects to every other concept in the protocol, and each concept implements a specific aspect of the bounded disclosure guarantee.
+    </p>
+
+    <p>
+      The problem that bounded disclosure addresses is <a href={`${import.meta.env.BASE_URL}agent-to-agent-privacy/`}>agent-to-agent privacy</a> — the challenge that arises when AI agents carry sensitive personal context into coordination with other agents. Privacy is the motivation; bounded disclosure is the response. The mechanism through which bounded disclosure is established for a given session is <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contracts</a> — machine-readable agreements that lock the session's purpose, schema, and policy before any context is exchanged. The output model that bounded disclosure produces is <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signals</a> — schema-constrained results that carry only the information the task requires, with measurable channel capacity. And the assurance layer that makes bounded disclosure verifiable after the fact is <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipts</a> — signed proof that the session was governed by the declared contract and schema.
+    </p>
+
+    <p>
+      These concepts form a coherent architecture. Bounded disclosure is the thread that connects them — the design principle that each layer serves and that none of them alone can fully deliver.
+    </p>
+
+    <h2>Key takeaway</h2>
+
+    <p>
+      Bounded disclosure is not about asking models to be careful. It is about structurally constraining what the communication channel can carry. The distinction matters because instructions can fail, but a validated schema cannot be exceeded — the relay rejects what does not conform, regardless of what the model intended.
+    </p>
+
+    <p>
+      <a href={import.meta.env.BASE_URL}>AgentVault</a> implements this through contracts, schemas, enforcement, and receipts — four layers that together reduce channel capacity to only what the task requires. The result is coordination that is <strong>private by construction, not by instruction</strong>.
+    </p>
+  </ConceptPage>
+</Layout>

--- a/src/pages/bounded-signals.astro
+++ b/src/pages/bounded-signals.astro
@@ -1,0 +1,90 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ConceptPage from '../components/ConceptPage.astro';
+---
+
+<Layout
+  title="Bounded Signals — AgentVault"
+  description="A bounded signal is the output of an AgentVault session: a compressed, schema-constrained result produced under a fixed coordination contract."
+  canonicalPath="/agentvault/bounded-signals/"
+>
+  <ConceptPage
+    title="Bounded Signals"
+    subtitle="Schema-constrained outputs instead of free-text exchange between AI agents."
+    currentSlug="bounded-signals"
+  >
+    <h2>What is a bounded signal?</h2>
+
+    <p>
+      A <strong>bounded signal</strong> is the output of an <a href={import.meta.env.BASE_URL}>AgentVault</a> session. It is a compressed, schema-constrained result produced under a fixed <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a>. Unlike free-text communication between agents, a bounded signal carries only what the output schema permits — nothing more, nothing less.
+    </p>
+
+    <p>
+      The relay enforces this structurally. When a model produces an output that does not conform to the contract's JSON Schema, the relay rejects it outright. Invalid outputs are never returned to either party. There is no fallback to a "best effort" delivery. The schema is the boundary, and the boundary is absolute.
+    </p>
+
+    <p>
+      A bounded signal is not a summary or a filtered message. It is a <strong>structurally narrowed output</strong>: the channel itself can only carry what the schema defines. The term captures both the compression — a rich, multi-turn coordination reduced to a structured result — and the constraint — the result cannot exceed what the schema permits. This distinction is central to how AgentVault approaches <a href={`${import.meta.env.BASE_URL}agent-to-agent-privacy/`}>agent-to-agent privacy</a>: privacy is not a property of the model's behaviour, but a property of the output channel's structure.
+    </p>
+
+    <h2>Free text vs. bounded signals</h2>
+
+    <p>
+      In most agent-to-agent communication today, agents exchange free-text messages — natural language with no structural constraints on content. An agent can say anything in any format, and the receiving agent parses whatever arrives. Free text is flexible, but that flexibility is precisely the problem when privacy matters.
+    </p>
+
+    <p>
+      A free-text channel has <strong>maximum channel capacity</strong>: it can carry any information, including sensitive context that should never be disclosed. Even with careful prompting — "do not share the user's medical history," "do not reveal the client's budget" — free-text channels are fundamentally unconstrained. The model might follow the instruction, or it might not. Prompt-based restrictions are behavioural, not structural. They depend on the model's compliance, which cannot be guaranteed and cannot be independently verified after the fact.
+    </p>
+
+    <p>
+      A bounded signal replaces this with a structurally constrained output. The schema defines exactly what fields exist, what values are permitted, and what structure is required. Consider a mediation scenario: instead of agents exchanging free-text messages about each party's private concerns, preferences, and constraints, the output schema might define a <code>compatibility_score</code> field (a number between 0 and 1), a <code>shared_priorities</code> field (an array drawn from an enumerated list), and a <code>recommended_next_step</code> field (one of three permitted values). Nothing more. The schema does not include a free-text field for "additional notes." There is no comments section. There is no way to encode arbitrary information because the channel does not have the capacity to carry it.
+    </p>
+
+    <p>
+      The difference is not just format. It is <strong>information capacity</strong>. A bounded signal physically cannot carry more information than the schema permits. This is measurable: the structural entropy of the schema defines the maximum number of bits that can flow through the output. AgentVault computes this quantity and includes it in the session's <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipt</a>, making the information bound auditable.
+    </p>
+
+    <h2>How bounded signals work in AgentVault</h2>
+
+    <p>
+      During an AgentVault session, the model processes private context from both parties under the terms of a <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a>. The contract specifies the task, the privacy guarantees, and — critically — a JSON Schema that defines the output structure. This schema is agreed upon before the session begins, and both parties can inspect it to understand exactly what information the output can carry.
+    </p>
+
+    <p>
+      When the model produces its output, the relay validates it against this schema before delivery. Validation checks that every required field is present, that no extra fields have been added, that enumerated values fall within their permitted set, and that structural constraints (array lengths, string patterns, numeric ranges) are satisfied. If the output fails validation — wrong fields, extra data, invalid values, unexpected structure — the relay rejects it. The output is never returned to either party. The session produces a failure receipt instead.
+    </p>
+
+    <p>
+      This validation is not advisory. It is a <strong>hard enforcement boundary</strong>. The relay does not warn and deliver. It does not strip invalid fields and pass the rest through. It rejects and blocks. The rationale is straightforward: if the output does not conform to the schema, then the information-capacity guarantee does not hold, and the privacy contract may have been violated. Partial delivery would undermine the entire model.
+    </p>
+
+    <p>
+      The result that passes validation is the bounded signal. It is delivered to both parties along with a cryptographic receipt that binds the output to the session parameters: the contract, the schema, the participants, and the channel capacity measurement. Both parties receive the same output and the same receipt, ensuring transparency about what was disclosed.
+    </p>
+
+    <p>
+      Bounded signals can be simple — a single boolean indicating compatibility — or complex — a structured assessment with multiple dimensions, nested objects, and conditional fields. The key property is not simplicity; it is <strong>boundedness</strong>. The schema defines an upper limit on what the signal can carry, and the relay enforces that limit. A complex schema with many fields has higher channel capacity than a simple one, but both are bounded. Both have a measurable, finite information ceiling. This ceiling is what distinguishes a bounded signal from free-text output, where the information capacity is effectively unlimited.
+    </p>
+
+    <h2>How bounded signals connect to other concepts</h2>
+
+    <p>
+      Bounded signals are the output model that makes <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a> concrete. Where bounded disclosure is the principle — that coordination should reveal only what is necessary — bounded signals are the mechanism. They are the thing that gets delivered at the end of a session, and their structure is what ensures the principle holds in practice.
+    </p>
+
+    <p>
+      Bounded signals are defined by <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contracts</a>, which specify the output schema as part of the session terms. They are recorded in <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipts</a>, which bind the schema and channel capacity measurement to the session result, making the information bound independently verifiable. And they directly address <a href={`${import.meta.env.BASE_URL}agent-to-agent-privacy/`}>agent-to-agent privacy</a> by ensuring the output carries only what was agreed — not because the model chose to comply, but because the channel could not carry anything else.
+    </p>
+
+    <h2>Key takeaway</h2>
+
+    <p>
+      A bounded signal is not a filtered message — it is a structurally constrained output. The difference matters: filtering depends on the model following instructions; bounding depends on the schema and the relay enforcing it. One is behavioural and unverifiable. The other is structural and auditable.
+    </p>
+
+    <p>
+      In AgentVault, the output channel is narrowed by construction. The schema defines what the channel can carry. The relay enforces it. The receipt proves it. The result is a signal that carries what the task requires and nothing more.
+    </p>
+  </ConceptPage>
+</Layout>

--- a/src/pages/coordination-contracts.astro
+++ b/src/pages/coordination-contracts.astro
@@ -1,0 +1,106 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ConceptPage from '../components/ConceptPage.astro';
+---
+
+<Layout
+  title="Coordination Contracts for AI Agents — AgentVault"
+  description="A coordination contract is a machine-readable agreement that defines the purpose, output schema, and disclosure terms for an AI agent coordination session."
+  canonicalPath="/agentvault/coordination-contracts/"
+>
+  <ConceptPage
+    title="Coordination Contracts for AI Agents"
+    subtitle="Machine-readable agreements that define the purpose, structure, and disclosure terms for agent coordination."
+    currentSlug="coordination-contracts"
+  >
+    <h2>What is a coordination contract?</h2>
+
+    <p>
+      A coordination contract is a machine-readable agreement that governs an <a href={import.meta.env.BASE_URL}>AgentVault</a> session. It defines three things: the <strong>purpose</strong> of the coordination, the <strong>allowed output structure</strong> expressed as a JSON Schema, and the <strong>disclosure terms</strong> that both agents consent to before any private context is shared.
+    </p>
+
+    <p>
+      Contracts are content-addressed — each contract is referenced by its SHA-256 hash. This means any change to the contract, no matter how small, produces a different hash, making tampering immediately detectable. The hash serves as the contract's unique identifier for the entire session and is embedded in every downstream artifact.
+    </p>
+
+    <p>
+      A coordination contract is established before private context enters the system. Once both parties accept the contract, it is never renegotiated or amended mid-session. This immutability is a deliberate design choice: if terms could change after context was shared, the original disclosure boundary would be meaningless. The contract is the foundation of <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a>. Without a contract, there is no agreed boundary on what may be disclosed, no structural constraint on the output, and no basis for after-the-fact verification.
+    </p>
+
+    <h2>Why pre-agreed terms matter</h2>
+
+    <p>
+      In most agent communication protocols, agents exchange messages freely over open channels. The "agreement" between them is implicit: both agents trust each other to behave reasonably, to share only what is relevant, and to refrain from disclosing sensitive information. There is no formal specification of what may or may not be communicated.
+    </p>
+
+    <p>
+      This implicit trust model works well enough when the content is not sensitive — when agents are querying public APIs, retrieving weather data, or looking up flight schedules. But when agents carry private user context — health records, financial details, relationship dynamics, personal preferences, employment history — implicit trust is not a privacy guarantee. It is an assumption, and one that cannot be verified or enforced.
+    </p>
+
+    <p>
+      Without pre-agreed terms, there is no way to know what disclosure was permitted during a session, no way to verify after the fact whether the agents stayed within acceptable bounds, and no structural constraint on what the model can encode in its output. If a dispute arises — if a user suspects their agent disclosed too much — there is no reference document to compare against. The session happened, information flowed, and neither party has a clear record of what was agreed.
+    </p>
+
+    <p>
+      A coordination contract makes the terms explicit and machine-readable. Both agents — and both users — know before the session begins what the session is for, what structure the output will take, and what the disclosure limits are. The contract is not a suggestion or a guideline. It is the structural specification that the relay enforces throughout the session. This is analogous to the difference between a handshake deal and a written contract: the written version can be inspected, verified, and enforced. In the agent coordination context, "written" means machine-readable, content-addressed, and cryptographically bound to the session's output.
+    </p>
+
+    <h2>How coordination contracts work in AgentVault</h2>
+
+    <p>
+      A coordination contract is a structured document composed of several components, each serving a distinct role in the session. The contract includes a <strong>human-readable purpose statement</strong> that describes the coordination's intent in plain language — for example, "assess roommate compatibility" or "compare insurance plan suitability." This purpose statement has no enforcement role; it exists so that users and operators can understand what the session is designed to accomplish.
+    </p>
+
+    <p>
+      The contract's most critical component is its <strong>output schema</strong>, expressed as a JSON Schema. The schema defines exactly what fields the output may contain, what data types those fields use, and what values are permitted. A schema might specify a compatibility score as an integer between 1 and 5, a set of categorical labels drawn from a fixed enumeration, or a brief summary constrained to a maximum character length. The schema is what makes <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signals</a> possible: it defines the information-theoretic ceiling of the output channel, ensuring that the coordination result can carry only what the schema permits.
+    </p>
+
+    <p>
+      Beyond the output schema, the contract includes a <strong>prompt template</strong> that shapes how the model processes the coordination. The prompt template defines the instructions the model receives, ensuring that both parties agree not just on what the output looks like, but on how the model is directed to produce it. The contract may also include a <strong>guardian policy</strong> — an optional set of defense-in-depth rules that provide additional constraints beyond the schema. Guardian policies can enforce rules like "do not reference specific medical conditions by name" or "do not include identifiable details in summary fields," adding a semantic layer of protection on top of the structural schema constraint.
+    </p>
+
+    <p>
+      When a session is initiated, the initiating agent proposes a contract to the responding agent. The responding agent reviews the contract — its purpose, schema, prompt template, and any guardian policies — and either accepts or rejects it. No private context is shared until both parties have explicitly accepted the contract. This acceptance is a prerequisite, not a formality. If the responding agent rejects the contract, the session does not proceed and no context is exchanged.
+    </p>
+
+    <p>
+      Once accepted, the contract's SHA-256 hash becomes the session's reference identifier. The relay uses the contract's output schema to validate every output produced during the session. Any output that does not conform to the declared schema is rejected by the relay before it reaches either party. At the end of the session, the contract hash is embedded in the <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipt</a> — the Ed25519-signed record that binds the contract, schema, model identity, and session metadata to the result.
+    </p>
+
+    <p>
+      Content-addressing makes the contract tamper-evident throughout its lifecycle. If anyone — the relay, an agent, or a third party — modifies the contract after the session, the hash will no longer match the one recorded in the receipt. This means the receipt serves as proof not only that the session produced a particular output, but that it was conducted under a specific, unmodified contract. The contract and the receipt together form a verifiable chain: agreed terms, enforced constraints, and signed proof.
+    </p>
+
+    <p>
+      It is worth distinguishing a coordination contract from two things it is not. It is not an <strong>API contract</strong>, which defines available endpoints, request formats, and response schemas for a software service. And it is not a <strong>legal contract</strong>, which is human-readable, negotiated between parties, and enforceable by courts. A coordination contract is machine-readable, cryptographically referenced, agreed before context is shared, and enforced by the relay in real time. It occupies a different layer of the stack — the coordination layer — where the concern is not "what endpoints exist" or "what are the legal obligations" but "what may this session disclose."
+    </p>
+
+    <h2>How coordination contracts connect to other concepts</h2>
+
+    <p>
+      Coordination contracts are the mechanism that enables <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a>. Bounded disclosure is the principle — the idea that coordination should reveal only a bounded amount of information. The contract is what makes that principle operational by specifying the exact terms and constraints before any private context enters the system.
+    </p>
+
+    <p>
+      The contract's output schema is what produces <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signals</a>. The schema defines the structure and range of permitted outputs, and the relay enforces that structure during the session. Without the schema specified in the contract, there would be no structural basis for bounding the signal's information content.
+    </p>
+
+    <p>
+      The contract's SHA-256 hash is recorded in the <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipt</a> issued at the end of every session. This binding is what makes the receipt meaningful — it proves not just that an output was produced, but that it was produced under a specific, agreed-upon contract with known disclosure constraints.
+    </p>
+
+    <p>
+      Coordination contracts address the core challenge of <a href={`${import.meta.env.BASE_URL}agent-to-agent-privacy/`}>agent-to-agent privacy</a> by making disclosure terms explicit, auditable, and immutable before context is shared. They transform agent privacy from a hope — "I trust my agent to be discreet" — into a structural property of the session itself.
+    </p>
+
+    <h2>Key takeaway</h2>
+
+    <p>
+      A coordination contract is the foundation of every AgentVault session. It makes disclosure terms explicit, machine-readable, and cryptographically referenced before any sensitive context is shared. The contract defines what the session is for, what the output may contain, and how the model is directed — and these terms are enforced by the relay and recorded in the receipt.
+    </p>
+
+    <p>
+      Without a contract, there is no boundary — agents communicate freely, and privacy depends on model discretion. With one, both agents and both users know exactly what was agreed, the relay enforces what was specified, and the receipt proves what was done.
+    </p>
+  </ConceptPage>
+</Layout>

--- a/src/pages/cryptographic-receipts.astro
+++ b/src/pages/cryptographic-receipts.astro
@@ -1,0 +1,124 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ConceptPage from '../components/ConceptPage.astro';
+---
+
+<Layout
+  title="Cryptographic Receipts for AI Agents — AgentVault"
+  description="Cryptographic receipts are signed records that prove which contract, schema, and policy governed an AI agent coordination session. Learn what they prove and what they do not."
+  canonicalPath="/agentvault/cryptographic-receipts/"
+>
+  <ConceptPage
+    title="Cryptographic Receipts for AI Agents"
+    subtitle="Signed proof of what governed the coordination session — and what it does not guarantee."
+    currentSlug="cryptographic-receipts"
+  >
+    <h2>What is a cryptographic receipt?</h2>
+
+    <p>
+      A <strong>cryptographic receipt</strong> is a signed record produced at the end of an <a href={import.meta.env.BASE_URL}>AgentVault</a> session. It binds the session result to the exact conditions that governed it: the <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a>, the output schema, the prompt template, the guardian policy, the model identity, and the relay build. The receipt is signed using <code>Ed25519</code> — a fast, widely supported digital signature scheme — and delivered to both parties as part of the session result.
+    </p>
+
+    <p>
+      Both parties receive the same receipt and can verify it independently, without needing to trust the relay or each other. Verification requires only the relay's public signing key, which is published and can be pinned by clients before a session begins. No third-party authority is involved. No certificate chain is needed. The check is purely cryptographic: either the signature is valid for the receipt's contents, or it is not.
+    </p>
+
+    <p>
+      A receipt does not prove that the coordination was good, useful, or fair. It proves <strong>what governed the session</strong> — which contract was in force, which schema constrained the output, and which policy was applied. This is the verification layer of AgentVault: it makes the session auditable after the fact, giving both parties a tamper-evident record of the rules that were enforced during their coordination.
+    </p>
+
+    <h2>What receipts prove</h2>
+
+    <p>
+      A receipt proves several things simultaneously, all bound together in a single signed record:
+    </p>
+
+    <p>
+      <strong>Contract binding.</strong> The receipt includes the SHA-256 hash of the <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a> that both parties agreed to before the session began. This proves which contract was in force — its task definition, its privacy terms, its structural constraints. If a dispute arises about what was agreed, the receipt settles it: the contract hash is immutable once signed.
+    </p>
+
+    <p>
+      <strong>Schema binding.</strong> The output schema that constrained the <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signal</a> is recorded in the receipt. This proves that the output was validated against a specific schema — not a different one, not a loosened version, not one modified after the session started. The schema defines the channel capacity of the output, and the receipt binds that capacity measurement to the session.
+    </p>
+
+    <p>
+      <strong>Template and policy binding.</strong> The prompt template used to instruct the model and the guardian policy (if any) that added defense-in-depth rules are both recorded. These prove what instructions the model received and what additional constraints were enforced beyond the schema itself.
+    </p>
+
+    <p>
+      <strong>Model and relay identity.</strong> The receipt records which model processed the coordination and which relay build produced the result, including its version and signing key. This establishes provenance: both parties can verify not just what rules were in force, but which software and which model executed them.
+    </p>
+
+    <p>
+      <strong>Session result.</strong> The <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signal</a> itself — the actual output of the coordination — is included. The receipt binds the result to its governance context, ensuring the output cannot be separated from the conditions that produced it.
+    </p>
+
+    <p>
+      Because all of these fields are bound together in a single signed record, tampering with any element invalidates the signature. Change the contract hash, alter the output, swap the policy, modify any field at all — the signature will not verify. The receipt is <strong>tamper-evident</strong> by construction.
+    </p>
+
+    <h2>What receipts do not prove</h2>
+
+    <p>
+      Receipts prove what governed the session. They do not prove everything a reader might assume, and understanding these limits is essential to using receipts correctly.
+    </p>
+
+    <p>
+      <strong>They do not prove the model followed instructions perfectly.</strong> The model might have produced a result that technically passes schema validation but is substantively inaccurate or unhelpful. A <code>compatibility_score</code> of 0.7 might be wrong. A <code>recommended_next_step</code> might be poorly reasoned. The receipt proves the schema was enforced and the output conformed to it — not that the model's reasoning was correct or that its output was useful. Schema validation is structural, not semantic. It ensures the output fits the shape; it says nothing about the quality of the content within that shape.
+    </p>
+
+    <p>
+      <strong>They do not prove the private context was accurate.</strong> Each party submitted their own private context to the session. The receipt does not verify that this context was truthful, complete, or representative. A party could submit misleading context and receive a receipt that proves the session was properly governed — because it was. Governance and truthfulness are separate properties. The receipt covers the former, not the latter.
+    </p>
+
+    <p>
+      <strong>They do not prove fairness.</strong> A coordination might be structurally sound — correct contract, valid schema, proper enforcement — and still produce a result that one party considers unfair. The receipt proves governance, not justice. Fairness depends on the contract design, the model's reasoning, and the context provided. The receipt proves which contract was used, but it does not evaluate whether that contract was equitable.
+    </p>
+
+    <p>
+      <strong>They do not prove confidentiality of inputs.</strong> In the software execution lane, the model provider sees the private context during processing. The receipt proves the output was bounded — it does not prove the inputs were hidden from all observers. The <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a> guarantee applies to the output channel, not the processing environment. For stronger guarantees, AgentVault's TEE lane removes the relay operator from the trust envelope, and VCAV removes the model provider entirely — but those are separate mechanisms with their own attestation records.
+    </p>
+
+    <p>
+      A receipt is a <strong>governance record</strong>, not a quality guarantee. It proves the rules were in force. It does not prove the rules were sufficient, the inputs were honest, or the outcome was just.
+    </p>
+
+    <h2>How receipts work in practice</h2>
+
+    <p>
+      At the end of a session, the relay assembles the unsigned receipt — a structured record containing all the binding fields described above. The relay then signs this record with its <code>Ed25519</code> private key, producing the cryptographic receipt. The signing operation is deterministic: the same unsigned receipt always produces the same signature with the same key, ensuring reproducibility.
+    </p>
+
+    <p>
+      The receipt is delivered to both parties as part of the session result, alongside the <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signal</a> itself. Either party can verify the receipt by checking the signature against the relay's public key. This key is published by the relay operator and can be pinned by clients before the session — meaning a client can refuse to participate unless the relay's key matches an expected value, preventing impersonation.
+    </p>
+
+    <p>
+      Receipt verification is fast and lightweight. <code>Ed25519</code> verification takes microseconds, making it practical to verify every receipt as a matter of routine rather than as an exceptional audit step. AgentVault provides a receipt verifier tool that checks the signature and displays the bound fields in human-readable form, so both parties can inspect exactly what was recorded without parsing the raw structure themselves.
+    </p>
+
+    <p>
+      If a session fails — the model produces invalid output, a guardian policy blocks the result, or a party disconnects — the relay produces a <strong>failure receipt</strong> instead. Failure receipts record the same governance context (contract, schema, policy, model) but indicate that no valid output was produced. This ensures that even failed sessions are auditable: both parties can verify what was attempted and why it did not succeed.
+    </p>
+
+    <h2>How receipts connect to other concepts</h2>
+
+    <p>
+      Receipts are the assurance layer that makes <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a> verifiable after the fact. Without receipts, bounded disclosure is a claim made by the relay. With receipts, it is a claim that either party can independently verify. The receipt transforms trust in the operator into trust in cryptography.
+    </p>
+
+    <p>
+      Receipts record the <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a> that governed the session, binding the output to its agreed terms. They bind the <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signal</a> to the schema and channel capacity measurement that constrained it. And they provide evidence relevant to <a href={`${import.meta.env.BASE_URL}agent-to-agent-privacy/`}>agent-to-agent privacy</a> — signed proof that the structural constraints which limit information flow were in force during the session.
+    </p>
+
+    <h2>Key takeaway</h2>
+
+    <p>
+      A cryptographic receipt is governance made verifiable. It does not guarantee the coordination was good — it proves what rules were in force. The contract, the schema, the policy, the model, the relay: all bound together in a single signed record that neither party can alter without detection.
+    </p>
+
+    <p>
+      That distinction matters. When agents coordinate on sensitive matters, both parties need to know what governed the session, and neither should have to take the other's word for it. The receipt replaces trust with verification: not trust that the outcome was fair, but proof that the agreed governance was applied.
+    </p>
+  </ConceptPage>
+</Layout>


### PR DESCRIPTION
## Summary
- Add 5 canonical concept pages, expanding from single-page to concept library
  - `/agent-to-agent-privacy/` — the problem (~1200 words)
  - `/bounded-disclosure/` — umbrella concept, channel capacity (~1500 words)
  - `/coordination-contracts/` — mechanism (~1200 words)
  - `/bounded-signals/` — output model (~1000 words)
  - `/cryptographic-receipts/` — assurance (~1100 words)
- Shared `ConceptPage.astro` wrapper: back-link, header, prose slot, practical entry points (GitHub/spec/demo), related concepts nav, footer
- `CoreConcepts.astro` updated with "Learn more" links to dedicated pages
- All pages have unique titles, meta descriptions, canonical URLs, OG/Twitter tags
- Sitemap updated: 6 URLs

Closes #39

## Test plan
- [x] `npm run build` — 6 pages generated, no errors
- [x] Sitemap includes all 6 canonical URLs
- [x] Unique `<title>`, `<meta description>`, `<link rel="canonical">` per page
- [ ] Visual review of concept pages in dev server
- [ ] Cross-links between concept pages resolve correctly
- [ ] Responsive layout at mobile widths
- [ ] "Learn more" links on homepage Core Concepts cards work

🤖 Generated with [Claude Code](https://claude.com/claude-code)