### PR TITLE
feat: homepage tone shift to open protocol project

### DIFF
--- a/src/components/sections/OpenProject.astro
+++ b/src/components/sections/OpenProject.astro
@@ -1,0 +1,92 @@
+---
+// OpenProject.astro
+// Brief section framing AgentVault as an open-source protocol project
+---
+
+<section class="section section--alt reveal" id="open-project">
+  <div class="container">
+    <div class="open-project">
+      <h2 class="open-project__title">An open protocol project</h2>
+      <div class="open-project__body">
+        <p>
+          AgentVault is an open-source protocol and reference implementation for bounded,
+          verifiable coordination between AI agents. The protocol design is still evolving.
+        </p>
+        <p>
+          The repository includes the protocol specification, a reference relay, a threat
+          model, receipt verification tools, and example scenarios you can run locally.
+        </p>
+        <p>
+          Contributions, critique, and independent implementations are welcome.
+          If you are building systems that experiment with agent-to-agent coordination,
+          we would be interested in hearing from you.
+        </p>
+      </div>
+      <ul class="open-project__links">
+        <li>
+          <a href="https://github.com/vcav-io/agentvault" target="_blank" rel="noopener noreferrer">
+            GitHub repository
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/vcav-io/agentvault/issues" target="_blank" rel="noopener noreferrer">
+            Issues
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/vcav-io/agentvault/blob/main/docs/protocol-spec.md" target="_blank" rel="noopener noreferrer">
+            Protocol specification
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/vcav-io/agentvault/blob/main/docs/threat-model.md" target="_blank" rel="noopener noreferrer">
+            Threat model
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<style>
+  .open-project {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .open-project__title {
+    margin-bottom: var(--space-lg);
+  }
+
+  .open-project__body p {
+    font-size: var(--text-base);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text);
+    max-width: none;
+  }
+
+  .open-project__body p + p {
+    margin-top: var(--space-md);
+  }
+
+  .open-project__links {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-md) var(--space-lg);
+    margin-top: var(--space-lg);
+    padding: 0;
+  }
+
+  .open-project__links a {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .open-project__links a:hover {
+    color: var(--color-accent-bright);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,6 +9,7 @@ import VaultFamily from '../components/sections/VaultFamily.astro';
 import LinksResources from '../components/sections/LinksResources.astro';
 import WhyThisMatters from '../components/sections/WhyThisMatters.astro';
 import FAQ from '../components/sections/FAQ.astro';
+import OpenProject from '../components/sections/OpenProject.astro';
 import AVLockup from '../components/icons/AVLockup.astro';
 import VCAVLockup from '../components/icons/VCAVLockup.astro';
 ---
@@ -27,7 +28,7 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
             AI agents are becoming delegates. When they coordinate, they carry sensitive personal context from their users into the interaction.
           </p>
           <p class="hero__claim hero__claim--sub">
-            AgentVault is a protocol for bounded disclosure — it constrains what agents can reveal to each other and produces a verifiable record of what governed the session.
+            AgentVault is an open protocol and reference implementation for bounded disclosure — it constrains what agents can reveal to each other and produces a verifiable record of what governed the session. The protocol design is still evolving.
           </p>
           <ul class="hero__guarantees font-mono">
             <li>Coordination contracts — agents agree on purpose, terms, and output structure before any context is shared</li>
@@ -103,6 +104,7 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
     <ProtocolOverview />
     <WhyThisMatters />
     <FAQ />
+    <OpenProject />
     <VaultFamily />
     <LinksResources />
 


### PR DESCRIPTION
## Summary
- Hero sub-claim reframed: "an open protocol and reference implementation"
- New OpenProject section between FAQ and Assurance Levels: frames AgentVault as open-source, welcomes contributions, links to repo/issues/spec/threat model

Closes #49

## Test plan
- [ ] Visual review of hero copy and OpenProject section
- [ ] Links resolve correctly (GitHub repo, issues, protocol spec, threat model)
- [ ] Responsive layout at mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)