### PR TITLE
fix: tighten semantic discipline across Phase 4 whitepapers

### DIFF
--- a/src/pages/guardian-policy-defense-in-depth.astro
+++ b/src/pages/guardian-policy-defense-in-depth.astro
@@ -20,7 +20,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      Schema validation is the primary enforcement layer — a strict enum field with four values permits only those four values. The guardian provides defense in depth: a second layer of checks applied to schema-valid output. If the schema is the structural constraint, the guardian is the additional mechanical constraint that catches what the schema alone cannot express.
+      Schema validation is the primary enforcement layer — a strict enum field with four values permits only those four values. The guardian provides a narrow second layer of mechanical checks applied to schema-valid output. If the schema is the structural constraint, the guardian is the additional mechanical constraint that catches what the schema alone cannot express. The guardian is intentionally modest: it is a secondary constraint layer, not the primary disclosure boundary.
     </p>
 
     <h2>How enforcement policies layer on schema constraints</h2>
@@ -41,11 +41,11 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>Policy scope and rule types</h2>
 
     <p>
-      A guardian enforcement policy has a scope of <code>RELAY_GLOBAL</code> — it applies to every session on the relay. The policy is loaded at relay startup, content-addressed by SHA-256 over its JCS canonical form, and bound into every receipt via the <code>guardian_policy_hash</code> commitment.
+      In the current implementation, a guardian enforcement policy has a scope of <code>RELAY_GLOBAL</code> — it applies to every session on the relay. The policy is loaded at relay startup, content-addressed by SHA-256 over its JCS canonical form, and bound into every receipt via the <code>guardian_policy_hash</code> commitment.
     </p>
 
     <p>
-      The current protocol version supports one rule type: <code>unicode_category_reject</code>. A rule of this type scans every string value in the output JSON and rejects the output if any string contains a character in the specified Unicode general category.
+      The current protocol version supports one rule type: <code>unicode_category_reject</code>. A rule of this type scans every string value in the output JSON and rejects the output if any string contains a character in the specified Unicode general category. This is intentionally narrow: the current rule surface is a modest starting point, not a rich policy engine.
     </p>
 
     <p>
@@ -68,11 +68,11 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      <strong><code>GATE</code></strong> — the relay aborts the session with <code>POLICY_GATE</code> and returns a constant-shape HTTP 422 error: <code>{'{"error": "OUTPUT_POLICY_VIOLATION"}'}</code>. No detail about which rule fired or what content triggered it is exposed. The output is never delivered to either participant. This prevents participants from reverse-engineering the guardian policy through error responses.
+      <strong><code>GATE</code></strong> — the relay aborts the session with <code>POLICY_GATE</code> and returns a constant-shape HTTP 422 error: <code>{'{"error": "OUTPUT_POLICY_VIOLATION"}'}</code>. No detail about which rule fired or what content triggered it is exposed. The output is never delivered to either participant. This reduces the risk of participants probing the guardian policy through error responses.
     </p>
 
     <p>
-      <strong><code>ADVISORY</code></strong> — the relay logs a warning but does not block the output. Advisory violations are not reported to participants. They exist for monitoring and gradual enforcement rollout.
+      <strong><code>ADVISORY</code></strong> — the relay logs a warning but does not block the output. Advisory violations are not reported to participants. This preserves the bounded response surface, but also means advisory mode is an operator-observability feature rather than a participant-facing guarantee. Advisory rules exist for monitoring and gradual enforcement rollout.
     </p>
 
     <h2>Content-addressed policy hashing and lockfile validation</h2>
@@ -92,7 +92,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>Multi-policy selection</h2>
 
     <p>
-      A single relay can serve multiple governance modes through multi-policy selection. The contract's <code>enforcement_policy_hash</code> field specifies which policy should govern the session. The relay loads all available policies at startup, indexes them by hash, and selects the matching policy when a session is created.
+      A single relay can serve multiple operator governance modes through multi-policy selection. The contract's <code>enforcement_policy_hash</code> field specifies which policy should govern the session. The relay loads all available policies at startup, indexes them by hash, and selects the matching policy when a session is created.
     </p>
 
     <p>

--- a/src/pages/how-coordination-contracts-work.astro
+++ b/src/pages/how-coordination-contracts-work.astro
@@ -4,7 +4,7 @@ import ConceptPage from '../components/ConceptPage.astro';
 
 const contractExample = `{
   "purpose_code": "COMPATIBILITY",
-  "output_schema_id": "vcav_e_compatibility_signal_v2",
+  "output_schema_id": "agentvault_compatibility_signal_v2",
 
   "output_schema": {
     "type": "object",
@@ -47,11 +47,11 @@ const contractExample = `{
     <h2>Why contracts exist</h2>
 
     <p>
-      A coordination contract defines the semantics of the bounded signal before any reasoning occurs. The vault enforces those semantics mechanically. Models cannot redefine them. This is the distinction between a schema (which constrains structure) and a contract (which binds governance).
+      A coordination contract defines the declared meaning, allowed structure, and governing artefacts for the bounded signal before any reasoning occurs. The vault enforces the agreed structure and referenced governance mechanically. Models cannot expand the channel beyond those constraints. This is the distinction between a schema (which constrains structure) and a contract (which binds governance).
     </p>
 
     <p>
-      An API schema tells you what shape the data has. A coordination contract tells you what both participants agreed to, what enforcement policy governs the session, what prompt template will be used, and what entropy budget bounds the output channel. The contract is a bilateral agreement — not a unilateral definition imposed by one party. Both participants must agree to the contract before any private context is exchanged.
+      An API schema tells you what shape the data has. A coordination contract tells you what both participants agreed to, what enforcement policy governs the session, what prompt template will be used, and what declared information budget and schema constraints govern the output channel. The contract is a bilateral agreement — not a unilateral definition imposed by one party. Both participants must agree to the contract before any private context is exchanged.
     </p>
 
     <h2>Three-part structure</h2>
@@ -61,7 +61,7 @@ const contractExample = `{
     </p>
 
     <p>
-      <strong>Consent boundary.</strong> The contract defines who participates (<code>participants</code>), what the session is for (<code>purpose_code</code>), and what constraints apply (<code>enforcement_policy_hash</code>, <code>model_constraints</code>). This establishes the consent boundary — what both parties have agreed to before any context is exchanged. The consent boundary is locked at session creation and cannot be modified mid-session.
+      <strong>Consent boundary.</strong> The contract defines who participates (<code>participants</code>), what the session is for (<code>purpose_code</code>), and what execution constraints apply (<code>enforcement_policy_hash</code>, <code>model_profile_id</code>, and related execution parameters). This establishes the consent boundary — what both parties have agreed to before any context is exchanged. The consent boundary is locked at session creation and cannot be modified mid-session.
     </p>
 
     <p>
@@ -87,7 +87,7 @@ const contractExample = `{
     </p>
 
     <p>
-      The contract hash is the root of the verification chain. From the contract, you can derive the expected schema hash, enforcement policy hash, prompt template hash, and model profile hash. If any of these artefacts were substituted after the contract was agreed, the hash chain breaks and verification fails.
+      The contract hash is the root of the verification chain. From the contract, a verifier can derive the expected hashes of the schema, enforcement policy, prompt template, and model profile reference. If any of these artefacts were substituted after the contract was agreed, the hash chain breaks and verification fails.
     </p>
 
     <p>
@@ -101,7 +101,7 @@ const contractExample = `{
     </p>
 
     <p>
-      A coordination contract is a bilateral agreement. Both participants agree to the same contract before submitting private context. The contract is content-addressed and immutable for the session duration. Neither party can change the terms mid-session. The contract binds not just the output structure but the prompt template, the enforcement policy, the model constraints, and the entropy budget. The receipt proves — after the fact — that this specific contract governed the session.
+      A coordination contract is a bilateral agreement. Both participants agree to the same contract before submitting private context. The contract is content-addressed and immutable for the session duration. Neither party can change the terms mid-session. The contract binds not just the output structure but the referenced governance artefacts and execution parameters that were agreed for the session. The receipt proves — after the fact — that this specific contract governed the session.
     </p>
 
     <p>
@@ -115,7 +115,7 @@ const contractExample = `{
     </p>
 
     <p>
-      <strong><code>entropy_budget_bits</code></strong> declares the advisory upper bound on output information content. The relay computes the actual channel capacity from the schema structure and records it in the receipt. A verifier can compare the declared budget against the computed capacity to check whether the schema is consistent with the claimed bound.
+      <strong><code>entropy_budget_bits</code></strong> declares the advisory upper bound on output information content. Where supported by the active receipt version and runtime, the relay computes the actual channel capacity from the schema structure and records it in the receipt. A verifier can compare the declared budget against the computed capacity to check whether the schema is consistent with the claimed bound.
     </p>
 
     <p>
@@ -123,7 +123,7 @@ const contractExample = `{
     </p>
 
     <p>
-      <strong><code>model_constraints</code></strong> specifies which providers and models are acceptable. The relay selects a model satisfying all constraints. The receipt records which model was actually used (as a claim at <code>SELF_ASSERTED</code> level, as an attestation at <code>PROVIDER_ATTESTED</code> level).
+      The contract can constrain the permitted model class or profile for the session via <strong><code>model_profile_id</code></strong>. The relay selects a model satisfying the profile requirements. The receipt records which model was actually used (as a claim at <code>SELF_ASSERTED</code> level, as an attestation at <code>PROVIDER_ATTESTED</code> level).
     </p>
 
     <p>
@@ -133,7 +133,7 @@ const contractExample = `{
     <h2>Key takeaway</h2>
 
     <p>
-      A coordination contract is the single root of trust for an AgentVault session. Everything that governs the session is either in the contract or referenced by content hash from the contract. The receipt proves, cryptographically, that this specific contract governed this specific session. Schema design is a security decision. Contract design is a governance decision. They are distinct concerns, bound together by content addressing.
+      A coordination contract is the root governance object for an AgentVault session. Everything that governs the session is either in the contract or referenced by content hash from the contract. The receipt proves, cryptographically, that this specific contract governed this specific session. Schema design is a security decision. Contract design is a governance decision. They are distinct concerns, bound together by content addressing.
     </p>
   </ConceptPage>
 </Layout>

--- a/src/pages/how-receipt-verification-works.astro
+++ b/src/pages/how-receipt-verification-works.astro
@@ -16,7 +16,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>Verification independence</h2>
 
     <p>
-      Verification requires the receipt, the contract, the enforcement policy, and the relay's public key. It does not require the runtime, the operator, or the model. This is the central result of the protocol's design: a third party who was not present during the session can verify everything about how it was governed.
+      Verification requires the receipt, the contract, the enforcement policy, and the relay's public key. It does not require the runtime, the operator, or the model. This is the central result of the protocol's design: a third party who was not present during the session can verify the receipt signature, the commitment chain, and the declared governance artefacts for the session.
     </p>
 
     <p>
@@ -56,7 +56,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      <strong>Step 4: Build the signing message.</strong> Prepend the domain separator: <code>"VCAV-RECEIPT-V2:" + canonical_json_string</code>. The colon is part of the separator. No null byte, no length prefix, no newline.
+      <strong>Step 4: Build the signing message.</strong> Prepend the domain separator: <code>"VCAV-RECEIPT-V2:" + canonical_json_string</code>. The shared receipt namespace remains VCAV-prefixed for family compatibility across AgentVault and VCAV. The colon is part of the separator. No null byte, no length prefix, no newline.
     </p>
 
     <p>
@@ -64,7 +64,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      <strong>Step 6: Verify.</strong> Base64url-decode the signature value. Hex-decode the verifying key (32 bytes). Verify the Ed25519 signature over the digest. If verification passes, the receipt was signed by the entity holding the corresponding private key and has not been modified since signing.
+      <strong>Step 6: Verify.</strong> Base64url-decode the signature value. Hex-decode the verifying key (32 bytes). Verify the Ed25519 signature over the digest. If verification passes, the receipt was signed by the entity holding the corresponding private key and has not been modified since signing. That proves provenance and integrity of the receipt document, not honesty of the underlying execution unless a stronger assurance tier is present.
     </p>
 
     <h2>What each commitment field proves</h2>
@@ -134,6 +134,10 @@ import ConceptPage from '../components/ConceptPage.astro';
 
     <p>
       These non-guarantees are not weaknesses to be papered over — they are architectural properties of the <code>SELF_ASSERTED</code> tier. Each higher assurance level progressively closes these gaps: <code>OPERATOR_AUDITED</code> adds external audit trails, <code>PROVIDER_ATTESTED</code> adds model identity verification, and <code>TEE_ATTESTED</code> removes the relay operator from the trust envelope entirely.
+    </p>
+
+    <p>
+      A verified receipt tells you what artefacts governed the session and that the signed record is intact. It does not, by itself, tell you whether the runtime was honest.
     </p>
   </ConceptPage>
 </Layout>

--- a/src/pages/integrating-agentvault.astro
+++ b/src/pages/integrating-agentvault.astro
@@ -13,7 +13,7 @@ import {
   computeRelayContractHash,
 } from 'agentvault-client/relay-contracts';
 
-// 1. Build a contract from a bundled template
+// 1. Build a contract from a bundled session template
 const contract = buildRelayContract('COMPATIBILITY', [
   'agent-alice',
   'agent-bob',
@@ -33,7 +33,8 @@ const result = await createAndSubmit(
 //   responderSubmitToken, responderReadToken,
 //   initiatorReadToken
 
-// 3. Send responder tokens to Bob (out-of-band)
+// 3. Transmit responder credentials to Bob
+//    through an authenticated application channel
 // Bob needs: sessionId, contractHash,
 //   responderSubmitToken, responderReadToken
 
@@ -49,7 +50,7 @@ const output = await pollUntilDone(
 
 const responderCode = `import { joinAndWait } from 'agentvault-client';
 
-// Tokens received from initiator (out-of-band)
+// Credentials received from initiator
 const output = await joinAndWait(
   { relayUrl: 'http://localhost:3100' },
   sessionId,
@@ -128,7 +129,7 @@ curl http://localhost:3100/health
     <h2>Two integration paths</h2>
 
     <p>
-      AgentVault provides two integration paths: a TypeScript client library for direct relay interaction, and an MCP server that exposes AgentVault operations as tools. The client library is lower-level and gives full control over session lifecycle. The MCP server is higher-level and designed for agents that already speak the MCP protocol.
+      AgentVault provides two integration paths: a direct client integration path and an MCP-based tool integration path. The TypeScript client library is lower-level and gives full control over session lifecycle. The MCP server is higher-level and designed for agents that already speak the MCP protocol. The examples below show the current minimal implementation path. Production integrations may wrap token handoff and session coordination inside higher-level agent or application channels.
     </p>
 
     <p>
@@ -154,7 +155,7 @@ curl http://localhost:3100/health
     <h3>Initiator side</h3>
 
     <p>
-      The initiator creates the session, submits their input, and distributes the responder's tokens:
+      The initiator creates the session, submits their input, and obtains the responder's join credentials for handoff:
     </p>
 
     <pre style={codeStyle} set:text={initiatorCode} />
@@ -168,7 +169,7 @@ curl http://localhost:3100/health
     <pre style={codeStyle} set:text={responderCode} />
 
     <p>
-      The <code>expectedContractHash</code> parameter is critical: the relay verifies it matches the session's actual contract hash and rejects with <code>CONTRACT_MISMATCH</code> if not. This prevents contract substitution attacks — the responder confirms they are joining the session they agreed to.
+      The <code>expectedContractHash</code> parameter is critical: the relay verifies it matches the session's actual contract hash and rejects with <code>CONTRACT_MISMATCH</code> if not. This prevents silent contract substitution at join time — the responder confirms they are joining the session they agreed to.
     </p>
 
     <h3>Contract builders</h3>
@@ -178,7 +179,7 @@ curl http://localhost:3100/health
     </p>
 
     <p>
-      <strong><code>buildRelayContract(purpose, participants)</code></strong> — builds a full contract from a bundled template with the output schema embedded inline. Available purpose codes: <code>COMPATIBILITY</code>, <code>MEDIATION</code>.
+      <strong><code>buildRelayContract(purpose, participants)</code></strong> — builds a full contract from a bundled session template with the output schema embedded inline. Available purpose codes: <code>COMPATIBILITY</code>, <code>MEDIATION</code>.
     </p>
 
     <p>

--- a/src/pages/understanding-agentvault-guarantees.astro
+++ b/src/pages/understanding-agentvault-guarantees.astro
@@ -16,7 +16,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>The core developer question</h2>
 
     <p>
-      Before integrating any coordination protocol, a developer needs to know precisely what it guarantees and what it does not. AgentVault is an agent-native bounded-disclosure coordination protocol. It enforces constraints on what information flows between participants. It does not evaluate whether a signal is correct, truthful, or aligned with anyone's intent. This page defines those boundaries precisely, qualified by execution lane.
+      Before integrating any coordination protocol, a developer needs to know precisely what it guarantees and what it does not. AgentVault is an agent-native bounded-disclosure coordination protocol. It constrains what can be emitted between participants by bounding the output channel with a contract, schema validation, and receipt-bound governance artefacts. It does not evaluate whether a signal is correct, truthful, or aligned with anyone's intent. Today, all production deployments operate at <code>SELF_ASSERTED</code>, which proves signed provenance of declared rules, not execution integrity. This page defines those boundaries, and distinguishes what is guaranteed by protocol structure from what still depends on the execution lane and trust model.
     </p>
 
     <h2>Layered responsibility model</h2>
@@ -26,7 +26,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      <strong>The vault (relay + guardian)</strong> enforces the consent boundary. It validates that the output conforms to the contract's JSON Schema, applies the guardian enforcement policy, signs a receipt binding all governance artefacts, and delivers only the bounded output to participants. The vault is a coordination primitive — it constrains the channel mechanically, without evaluating what the signal means.
+      <strong>The vault (relay + guardian)</strong> enforces the agreed output boundary and the declared session governance. It validates that the output conforms to the contract's JSON Schema, applies the guardian enforcement policy, signs a receipt binding all governance artefacts, and delivers only the bounded output to participants. The vault is a coordination primitive — it constrains the channel mechanically, without evaluating what the signal means.
     </p>
 
     <p>
@@ -34,7 +34,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      <strong>Participants (humans)</strong> define the consent boundary by agreeing to the coordination contract before any context is exchanged. The contract specifies the purpose, output schema, enforcement policy, and model constraints. Participants are responsible for schema design — which is a security decision, because the schema determines the channel capacity.
+      <strong>Participants (humans)</strong> define the consent boundary by agreeing to the coordination contract before any context is exchanged. The contract specifies the purpose, output schema, referenced enforcement policy, and execution constraints such as model profile or model-selection requirements. Participants are responsible for schema design — which is a security decision, because the schema determines the channel capacity.
     </p>
 
     <h2>Architecture</h2>
@@ -70,25 +70,25 @@ import ConceptPage from '../components/ConceptPage.astro';
    └──────────────────────────────────────────────────┘</pre>
 
     <p>
-      Verifier independence is the central result of the protocol's design. A third party can verify everything about how a session was governed without needing access to the relay, the operator, or the model that produced the output.
+      Verifier independence is the central result of the protocol's design. A third party can verify the declared governance artefacts and receipt commitments for a session without needing access to the relay, the operator, or the model that produced the output.
     </p>
 
     <h2>What AgentVault guarantees</h2>
 
     <p>
-      <strong>Consent boundary enforcement.</strong> Neither participant sees the other's raw input. The relay routes inputs and outputs separately. The output that leaves the relay conforms to the JSON Schema specified in the coordination contract. Output that fails schema validation is rejected — it never reaches either participant.
+      <strong>Participant boundary enforcement.</strong> Neither participant receives the other's raw input from the relay. The relay routes inputs and outputs separately. The output that leaves the relay conforms to the JSON Schema specified in the coordination contract. Output that fails schema validation is rejected — it never reaches either participant.
     </p>
 
     <p>
-      <strong>Signal compression.</strong> The output channel is structurally narrowed. An all-enum output schema with a 25-bit entropy budget carries at most 25 bits of information, regardless of what the model attempts to produce. This is a structural property of the schema, not a property of the model's compliance. The relay enforces it mechanically — the guardian never evaluates whether a signal is correct, only whether the signal is allowed.
+      <strong>Signal compression.</strong> The output channel is structurally narrowed. An all-enum output schema with a computed channel capacity of 25 bits can carry at most 25 bits through the bounded output channel, regardless of what the model attempts to produce. This is a structural property of the schema, not a property of the model's compliance. The relay enforces it mechanically — the guardian never evaluates whether a signal is correct, only whether the signal is allowed.
     </p>
 
     <p>
-      <strong>Cryptographic binding.</strong> Every completed session produces a signed receipt (Ed25519) that binds the contract hash, output schema hash, prompt template hash, guardian policy hash, model profile hash, relay build hash, bounded output hash, and per-participant input commitment hashes. A recipient with the relay's public key can verify that the receipt was produced by the relay and that none of the bound fields have been modified since signing.
+      <strong>Cryptographic binding.</strong> Every completed session produces a signed receipt (Ed25519) that binds the session to specific governance artefacts and output commitments — including the contract hash, output schema hash, prompt template hash, guardian policy hash, model profile hash, relay build hash, bounded output hash, and per-participant input commitment hashes. A recipient with the relay's public key can verify that the receipt was produced by the relay and that none of the bound fields have been modified since signing.
     </p>
 
     <p>
-      <strong>Independent verification.</strong> Verification requires the receipt, the contract, the policy, and the relay's public key. It does not require the runtime, the operator, or the model. A verifier who holds these artefacts can independently recompute all commitment hashes and confirm they match the receipt.
+      <strong>Independent verification.</strong> Verification requires the receipt, the contract, the policy, and the relay's public key. It does not require the runtime, the operator, or the model. A verifier who holds these artefacts can independently recompute all commitment hashes and confirm they match the receipt. At <code>SELF_ASSERTED</code>, this proves provenance and consistency of declarations, not honest execution.
     </p>
 
     <h2>What AgentVault does not guarantee</h2>
@@ -112,7 +112,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>Execution lanes: what each adds</h2>
 
     <p>
-      AgentVault defines two execution lanes. Every guarantee statement must specify which lane it applies to.
+      AgentVault defines two execution lanes. The protocol structure is stable across lanes; what changes is who must be trusted for truthful execution. Every guarantee statement must specify which lane it applies to.
     </p>
 
     <p>


### PR DESCRIPTION
## Summary
- Applies line-by-line revision notes from editorial review of all 5 Phase 4 whitepaper pages
- Moves SELF_ASSERTED caveat earlier on guarantees page so readers don't over-credit the protocol
- Replaces "enforces semantics mechanically" with structure/governance language (stops implying semantic correctness)
- Removes legacy `vcav_e_` naming from contract JSON example
- Calibrates guardian as proportionate narrow secondary layer, not a rich policy engine
- Uses `model_profile_id` consistently instead of `model_constraints`
- Adds provenance vs integrity distinction at every verification touchpoint
- Distinguishes current implementation plumbing from intended long-term ergonomics on integration page
- Explains VCAV-prefixed receipt namespace for family compatibility

## Test plan
- [x] `npm run build` passes with no errors
- [x] All 5 pages render correctly (visually verified in previous session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)