### PR TITLE
fix: update supporting pages for shipped milestones

### DIFF
--- a/src/pages/a2a-and-agentvault.astro
+++ b/src/pages/a2a-and-agentvault.astro
@@ -45,7 +45,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </ul>
 
     <p>
-      These are genuinely useful primitives. They solve the interoperability problem — making it possible for agents built by different vendors to communicate without bespoke integrations. A2A is evolving, and its capabilities will likely expand over time.
+      These are genuinely useful primitives. They solve the interoperability problem — making it possible for agents built by different vendors to communicate without bespoke integrations.
     </p>
 
     <h2>What AgentVault provides</h2>

--- a/src/pages/agents-reason-together.astro
+++ b/src/pages/agents-reason-together.astro
@@ -121,7 +121,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      AgentVault handles this through what might be called a trust envelope. At its most permissive, the envelope includes the model, the relay, and a broad output schema — sufficient for low-sensitivity coordination. As stakes rise, the envelope tightens: narrower schemas, stricter guardian policies, and — for the highest-stakes scenarios — confidential execution environments where even the relay operator cannot observe the private context during processing. The same bounded-disclosure principle applies throughout; only the tightness of the boundary changes.
+      AgentVault handles this through a graduated trust envelope. At its most permissive — the software lane (<code>SELF_ASSERTED</code>) — the envelope includes the model, the relay, and a broad output schema, sufficient for low-sensitivity coordination. As stakes rise, the envelope tightens: narrower schemas, stricter guardian policies, and the TEE lane (<code>HARDWARE_ATTESTED</code>, operational on AMD SEV-SNP confidential VMs) where the relay operator is excluded from plaintext inputs. For the highest-stakes scenarios, VCAV runs local models inside a sealed execution environment where even the model provider is outside the trust boundary. The same bounded-disclosure principle applies throughout; only the tightness of the boundary changes.
     </p>
 
     <h2>The foundational claim</h2>

--- a/src/pages/coordination-contracts.astro
+++ b/src/pages/coordination-contracts.astro
@@ -20,7 +20,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      Contracts are content-addressed — each contract is referenced by its SHA-256 hash. This means any change to the contract, no matter how small, produces a different hash, making tampering immediately detectable. The hash serves as the contract's unique identifier for the entire session and is embedded in every downstream artifact.
+      Contracts are content-addressed — each contract is referenced by its SHA-256 hash. This means any change to the contract, no matter how small, produces a different hash, making tampering immediately detectable. The hash serves as the contract's unique identifier for the entire session and is embedded in every downstream artifact. Contracts are composed from content-addressed registry artefacts — schemas, policies, model profiles, and prompt programs — each independently verifiable by its SHA-256 digest. The <code>av-contract</code> CLI resolves artefacts by digest, alias, or channel reference and validates compatibility before producing the final contract.
     </p>
 
     <p>

--- a/src/pages/cryptographic-receipts.astro
+++ b/src/pages/cryptographic-receipts.astro
@@ -54,6 +54,10 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
+      Receipt v2 separates these fields into two explicit sections: <strong>commitments</strong> (cryptographically verifiable — contract hash, schema hash, input commitment hashes, bounded output hash) and <strong>claims</strong> (relay-asserted — model identity, token usage, latency, channel capacity measurement). This distinction makes explicit what a verifier can check independently versus what requires trusting the relay. Both sections are bound by the same Ed25519 signature.
+    </p>
+
+    <p>
       Because all of these fields are bound together in a single signed record, tampering with any element invalidates the signature. Change the contract hash, alter the output, swap the policy, modify any field at all — the signature will not verify. The receipt is <strong>tamper-evident</strong> by construction.
     </p>
 
@@ -76,7 +80,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      <strong>They do not prove confidentiality of inputs.</strong> In the software execution lane, the model provider sees the private context during processing. The receipt proves the output was bounded — it does not prove the inputs were hidden from all observers. The <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a> guarantee applies to the output channel, not the processing environment. For stronger guarantees, AgentVault's TEE lane removes the relay operator from the trust envelope, and VCAV removes the model provider entirely — but those are separate mechanisms with their own attestation records.
+      <strong>They do not prove confidentiality of inputs.</strong> In the software execution lane, the model provider sees the private context during processing. The receipt proves the output was bounded — it does not prove the inputs were hidden from all observers. The <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a> guarantee applies to the output channel, not the processing environment. The TEE lane (operational on AMD SEV-SNP confidential VMs) removes the relay operator from the trust envelope, and the receipt includes TEE attestation data — attestation hash, transcript hash, and receipt signing public key — verifiable against the hardware vendor's root of trust. VCAV removes the model provider entirely. These are separate mechanisms with their own attestation records.
     </p>
 
     <p>

--- a/src/pages/integrating-agentvault.astro
+++ b/src/pages/integrating-agentvault.astro
@@ -149,7 +149,7 @@ curl http://localhost:3100/health
     <pre style={codeStyle}>npm install github:vcav-io/agentvault#main -- --workspace=packages/agentvault-client</pre>
 
     <p>
-      The package is not yet published to npm. Install directly from the repository, or use a <code>file:</code> dependency if you have a local checkout.
+      The package is not yet on npm. Install directly from the repository, or use a <code>file:</code> dependency if you have a local checkout.
     </p>
 
     <h3>Initiator side</h3>

--- a/src/pages/understanding-agentvault-guarantees.astro
+++ b/src/pages/understanding-agentvault-guarantees.astro
@@ -16,7 +16,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>The core developer question</h2>
 
     <p>
-      Before integrating any coordination protocol, a developer needs to know precisely what it guarantees and what it does not. AgentVault is an agent-native bounded-disclosure coordination protocol. It constrains what can be emitted between participants by bounding the output channel with a contract, schema validation, and receipt-bound governance artefacts. It does not evaluate whether a signal is correct, truthful, or aligned with anyone's intent. Today, all production deployments operate at <code>SELF_ASSERTED</code>, which proves signed provenance of declared rules, not execution integrity. This page defines those boundaries, and distinguishes what is guaranteed by protocol structure from what still depends on the execution lane and trust model.
+      Before integrating any coordination protocol, a developer needs to know precisely what it guarantees and what it does not. AgentVault is an agent-native bounded-disclosure coordination protocol. It constrains what can be emitted between participants by bounding the output channel with a contract, schema validation, and receipt-bound governance artefacts. It does not evaluate whether a signal is correct, truthful, or aligned with anyone's intent. In the software lane, deployments operate at <code>SELF_ASSERTED</code>, which proves signed provenance of declared rules, not execution integrity. The TEE lane raises this to <code>HARDWARE_ATTESTED</code>. This page defines those boundaries, and distinguishes what is guaranteed by protocol structure from what still depends on the execution lane and trust model.
     </p>
 
     <h2>Layered responsibility model</h2>
@@ -144,7 +144,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>Current limitations</h2>
 
     <p>
-      All current AgentVault deployments operate at <code>SELF_ASSERTED</code> assurance level. Receipt verification proves provenance (which relay signed it), not integrity of the underlying execution. The TEE lane and provider attestation are defined in the schema and receipt spec but are not yet active in production. Inputs travel over TLS but are not encrypted end-to-end — the relay has plaintext access. Cross-session entropy budget accumulation is not yet implemented (the budget resets per session). Fair exchange (simultaneous delivery to both participants) is not addressed by the protocol.
+      In the software lane, AgentVault operates at <code>SELF_ASSERTED</code> assurance level. Receipt verification proves provenance (which relay signed it), not integrity of the underlying execution. The TEE lane is operational — validated on AMD SEV-SNP confidential VMs (GCP N2D, AMD Milan) — and raises assurance to <code>HARDWARE_ATTESTED</code>, where the operator is excluded from plaintext and the receipt is bound to the measured execution environment. Provider attestation (<code>PROVIDER_ATTESTED</code>) is defined in the receipt schema but not yet implemented. Inputs travel over TLS but are not encrypted end-to-end — in the software lane, the relay has plaintext access. Cross-session entropy budget accumulation is not yet implemented (the budget resets per session). Fair exchange (simultaneous delivery to both participants) is not addressed by the protocol.
     </p>
   </ConceptPage>
 </Layout>


### PR DESCRIPTION
## Summary

- **understanding-agentvault-guarantees**: TEE lane described as operational (HARDWARE_ATTESTED), not "not yet active in production"
- **coordination-contracts**: Added registry artefacts and `av-contract` CLI context to content-addressing description
- **cryptographic-receipts**: Added receipt v2 commitments/claims split explanation; updated TEE attestation language to reflect operational state
- **integrating-agentvault**: Softened "not yet published to npm" → "not yet on npm"
- **a2a-and-agentvault**: Removed speculative "will likely expand over time"
- **agents-reason-together**: Named assurance tiers explicitly (software lane/SELF_ASSERTED, TEE lane/HARDWARE_ATTESTED, VCAV)

## Test plan
- [ ] `npm run dev` — verify all 6 pages render without errors
- [ ] Spot-check edited paragraphs for coherence

🤖 Generated with [Claude Code](https://claude.com/claude-code)