### PR TITLE
fix: point hero protocol link to protocol-spec.md

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,7 +40,7 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
           </ul>
           <div class="hero__ctas">
             <a href="https://github.com/vcav-io/agentvault" class="hero__cta" target="_blank" rel="noopener noreferrer">View on GitHub</a>
-            <a href="#protocol" class="hero__cta">Read the Protocol</a>
+            <a href="https://github.com/vcav-io/agentvault/blob/main/docs/protocol-spec.md" class="hero__cta" target="_blank" rel="noopener noreferrer">Read the Protocol</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- "Read the Protocol" now links to the normative protocol spec on GitHub instead of scrolling to the on-page summary

## Test plan

- [ ] Link opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)