### PR TITLE
docs: temper website risk framing claims

### DIFF
--- a/src/pages/agent-to-agent-privacy.astro
+++ b/src/pages/agent-to-agent-privacy.astro
@@ -108,7 +108,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     <h2>Key takeaway</h2>
 
     <p>
-      Agent interoperability makes coordination possible. Agent-to-agent privacy makes it safe. As AI agents become more capable and more deeply integrated into personal and professional life, the amount of sensitive context they carry will only grow. Without structural privacy guarantees at the coordination layer, every agent-to-agent interaction is a potential disclosure event.
+      Agent interoperability makes coordination possible. Agent-to-agent privacy makes it safer. As AI agents become more capable and more deeply integrated into personal and professional life, the amount of sensitive context they carry will only grow. Without structural privacy guarantees at the coordination layer, every context-rich agent-to-agent interaction over an unbounded channel is a potential disclosure event.
     </p>
 
     <p>

--- a/src/pages/how-to-stop-ai-agents-leaking-private-context.astro
+++ b/src/pages/how-to-stop-ai-agents-leaking-private-context.astro
@@ -40,7 +40,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      This is not a hypothetical risk. It is a structural property of any system where context-rich agents communicate over free-text channels.
+      Even where the public incident record is still emerging, this is a predictable structural risk of any system where context-rich agents communicate over free-text channels.
     </p>
 
     <h2>Why "be careful" does not work</h2>

--- a/src/pages/why-agent-interoperability-needs-a-privacy-layer.astro
+++ b/src/pages/why-agent-interoperability-needs-a-privacy-layer.astro
@@ -88,7 +88,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      This is not a hypothetical risk. It is a structural property of any system where context-rich agents communicate over unconstrained channels. As agents gain access to more personal data — calendars, health records, financial accounts, communications — the disclosure surface grows with every new integration.
+      Even where the public incident record is still emerging, this is a predictable structural risk of any system where context-rich agents communicate over unconstrained channels. As agents gain access to more personal data — calendars, health records, financial accounts, communications — the disclosure surface grows with every new integration.
     </p>
 
     <h2>How a privacy layer works</h2>
@@ -123,7 +123,7 @@ import ConceptPage from '../components/ConceptPage.astro';
     </p>
 
     <p>
-      As the agent ecosystem matures, privacy will not be an optional add-on. It will be a required layer — as fundamental to agent coordination as TLS is to web communication. The question is not whether agent interoperability needs a privacy layer. The question is how quickly the ecosystem recognizes it. <a href="https://github.com/vcav-io/agentvault" target="_blank" rel="noopener noreferrer">AgentVault</a> provides that layer today.
+      As the agent ecosystem matures, we expect privacy to become a required layer rather than an optional add-on — not because the exact failure class is already richly documented in production, but because delegated coordination will need disclosure controls in the same way web communication needed transport security. The question is not whether agent interoperability benefits from a privacy layer. The question is how quickly the ecosystem recognizes it. <a href="https://github.com/vcav-io/agentvault" target="_blank" rel="noopener noreferrer">AgentVault</a> provides one approach today.
     </p>
   </ConceptPage>
 </Layout>


### PR DESCRIPTION
## Summary
- soften a few website claims that overstated how documented the exact A2A leakage risk already is
- keep the positioning focused on an emerging, predictable structural risk rather than a richly documented current incident class
- leave the broader product framing unchanged

## Testing
- npm run build
