### PR TITLE
feat: add delegated coordination article

### DIFF
--- a/src/components/ConceptPage.astro
+++ b/src/components/ConceptPage.astro
@@ -23,6 +23,7 @@ const articles = [
   { slug: 'a2a-and-agentvault', label: 'A2A and AgentVault' },
   { slug: 'structured-outputs-not-enough', label: 'Structured Outputs Are Not Enough' },
   { slug: 'how-to-stop-ai-agents-leaking-private-context', label: 'Stop Agents Leaking Context' },
+  { slug: 'when-your-ai-talks-to-my-ai', label: 'When Your AI Talks to My AI' },
   { slug: 'agents-reason-together', label: 'When Agents Reason Together' },
   { slug: 'understanding-agentvault-guarantees', label: 'Understanding Guarantees' },
   { slug: 'how-coordination-contracts-work', label: 'How Contracts Work' },

--- a/src/components/simulation/ComparisonSimulation.astro
+++ b/src/components/simulation/ComparisonSimulation.astro
@@ -1,0 +1,1152 @@
+---
+// Article comparison simulation — same scenario, two coordination models
+---
+
+<section class="compare-sim" aria-label="Illustrative simulation">
+  <div class="compare-sim__intro">
+    <p class="compare-sim__eyebrow font-mono">Illustrative simulation</p>
+    <h2 class="compare-sim__title">The same reference check under two different coordination models</h2>
+    <p class="compare-sim__subtitle text-secondary">
+      Both modules begin with the same employment-reference request. The difference is the communication channel: open-ended free text on top, bounded AgentVault coordination underneath.
+    </p>
+  </div>
+
+  <div class="compare-sim__modules">
+    <div class="compare-module" data-compare-sim data-variant="unbounded">
+      <div class="compare-module__header">
+        <div class="compare-module__text">
+          <p class="compare-module__label font-mono">Mode A</p>
+          <h3 class="compare-module__title">Unbounded agent exchange</h3>
+          <p class="compare-module__subtitle text-secondary">
+            Useful intent, but no contract, no schema limit, and no structural rule about what the agents are allowed to reveal.
+          </p>
+        </div>
+        <div class="compare-module__controls">
+          <button class="compare-btn" data-role="toggle" aria-label="Play simulation">
+            <span data-role="toggle-label">Play</span>
+          </button>
+          <button class="compare-btn compare-btn--secondary" data-role="replay" style="display:none" aria-label="Replay simulation">
+            Replay
+          </button>
+          <div class="compare-progress">
+            <div class="compare-progress__track">
+              <div class="compare-progress__bar" data-role="progress-bar"></div>
+            </div>
+            <span class="compare-progress__time font-mono" data-role="progress-time"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="sim-grid">
+        <div class="sim-panel sim-panel--chat panel--dim" data-role="panel-left" aria-label="Requester agent chat">
+          <div class="sim-panel__header">
+            <span class="sim-panel__agent-name">Maya <span class="sim-panel__role">(hiring manager)</span></span>
+            <span class="sim-panel__agent-label font-mono">MayaBot</span>
+          </div>
+          <div class="sim-panel__messages" data-role="messages-left"></div>
+        </div>
+
+        <div class="sim-panel sim-panel--vault panel--dim" data-role="panel-centre" aria-label="Unbounded exchange trace">
+          <div class="sim-panel__header">
+            <span class="sim-panel__vault-label font-mono">Direct free-text exchange</span>
+          </div>
+          <div class="sim-panel__vault-scroll">
+            <div class="sim-panel__vault-events" data-role="vault-events"></div>
+          </div>
+          <div class="signal-overlay" data-role="signal-overlay"></div>
+        </div>
+
+        <div class="sim-panel sim-panel--chat panel--dim" data-role="panel-right" aria-label="Former manager agent chat">
+          <div class="sim-panel__header">
+            <span class="sim-panel__agent-name">Elias <span class="sim-panel__role">(former manager)</span></span>
+            <span class="sim-panel__agent-label font-mono">EliasBot</span>
+          </div>
+          <div class="sim-panel__messages" data-role="messages-right"></div>
+        </div>
+      </div>
+
+      <div class="sim-timeline" data-role="timeline" aria-label="Unbounded comparison timeline"></div>
+      <noscript>
+        <p class="compare-module__noscript text-secondary">
+          Enable JavaScript to play the illustrative comparison. In the unbounded version, the hiring signal arrives mixed with private context that was never meant to cross the boundary.
+        </p>
+      </noscript>
+    </div>
+
+    <div class="compare-module" data-compare-sim data-variant="bounded">
+      <div class="compare-module__header">
+        <div class="compare-module__text">
+          <p class="compare-module__label font-mono">Mode B</p>
+          <h3 class="compare-module__title">Bounded AgentVault exchange</h3>
+          <p class="compare-module__subtitle text-secondary">
+            The same delegated behavior, but now the agents coordinate under an agreed contract with schema-bound output and receipt-backed enforcement.
+          </p>
+        </div>
+        <div class="compare-module__controls">
+          <button class="compare-btn" data-role="toggle" aria-label="Play simulation">
+            <span data-role="toggle-label">Play</span>
+          </button>
+          <button class="compare-btn compare-btn--secondary" data-role="replay" style="display:none" aria-label="Replay simulation">
+            Replay
+          </button>
+          <div class="compare-progress">
+            <div class="compare-progress__track">
+              <div class="compare-progress__bar" data-role="progress-bar"></div>
+            </div>
+            <span class="compare-progress__time font-mono" data-role="progress-time"></span>
+          </div>
+        </div>
+      </div>
+
+      <div class="sim-grid">
+        <div class="sim-panel sim-panel--chat panel--dim" data-role="panel-left" aria-label="Requester agent chat">
+          <div class="sim-panel__header">
+            <span class="sim-panel__agent-name">Maya <span class="sim-panel__role">(hiring manager)</span></span>
+            <span class="sim-panel__agent-label font-mono">MayaBot</span>
+          </div>
+          <div class="sim-panel__messages" data-role="messages-left"></div>
+        </div>
+
+        <div class="sim-panel sim-panel--vault panel--dim" data-role="panel-centre" aria-label="Bounded AgentVault exchange trace">
+          <div class="sim-panel__header">
+            <span class="sim-panel__vault-label font-mono">AgentVault — bounded reference check</span>
+          </div>
+          <div class="sim-panel__vault-scroll">
+            <div class="sim-panel__vault-events" data-role="vault-events"></div>
+          </div>
+          <div class="signal-overlay" data-role="signal-overlay"></div>
+        </div>
+
+        <div class="sim-panel sim-panel--chat panel--dim" data-role="panel-right" aria-label="Former manager agent chat">
+          <div class="sim-panel__header">
+            <span class="sim-panel__agent-name">Elias <span class="sim-panel__role">(former manager)</span></span>
+            <span class="sim-panel__agent-label font-mono">EliasBot</span>
+          </div>
+          <div class="sim-panel__messages" data-role="messages-right"></div>
+        </div>
+      </div>
+
+      <div class="sim-timeline" data-role="timeline" aria-label="Bounded comparison timeline"></div>
+      <noscript>
+        <p class="compare-module__noscript text-secondary">
+          Enable JavaScript to play the illustrative comparison. In the bounded version, the result is limited to a reference signal instead of the private management history behind it.
+        </p>
+      </noscript>
+    </div>
+  </div>
+</section>
+
+<script>
+  import { SimulationEngine } from './engine.ts';
+  import { SimulationRenderer } from './renderer.ts';
+  import { boundedEmploymentReferenceScenario, unboundedEmploymentReferenceScenario } from './comparison-scenarios.ts';
+
+  const scenarios = {
+    unbounded: unboundedEmploymentReferenceScenario,
+    bounded: boundedEmploymentReferenceScenario,
+  };
+
+  function initModule(root) {
+    const variant = root.dataset.variant;
+    const scenario = scenarios[variant];
+    if (!scenario) return;
+
+    const els = {
+      left: root.querySelector('[data-role="panel-left"]'),
+      centre: root.querySelector('[data-role="panel-centre"]'),
+      right: root.querySelector('[data-role="panel-right"]'),
+      leftMessages: root.querySelector('[data-role="messages-left"]'),
+      rightMessages: root.querySelector('[data-role="messages-right"]'),
+      vaultEvents: root.querySelector('[data-role="vault-events"]'),
+      progressBar: root.querySelector('[data-role="progress-bar"]'),
+      progressTime: root.querySelector('[data-role="progress-time"]'),
+      signalOverlay: root.querySelector('[data-role="signal-overlay"]'),
+      timeline: root.querySelector('[data-role="timeline"]'),
+    };
+
+    const toggleBtn = root.querySelector('[data-role="toggle"]');
+    const replayBtn = root.querySelector('[data-role="replay"]');
+    const toggleLabel = root.querySelector('[data-role="toggle-label"]');
+
+    if (!els.left || !els.centre || !els.right || !els.leftMessages || !els.rightMessages || !els.vaultEvents || !els.progressBar || !els.progressTime || !els.signalOverlay || !toggleBtn || !replayBtn || !toggleLabel) {
+      return;
+    }
+
+    const renderer = new SimulationRenderer({
+      left: els.left,
+      centre: els.centre,
+      right: els.right,
+      leftMessages: els.leftMessages,
+      rightMessages: els.rightMessages,
+      vaultEvents: els.vaultEvents,
+      progressBar: els.progressBar,
+      progressTime: els.progressTime,
+      signalOverlay: els.signalOverlay,
+      ...(els.timeline ? { timeline: els.timeline } : {}),
+    });
+
+    const setToggleState = (state) => {
+      toggleLabel.textContent = state === 'play' ? 'Play' : 'Pause';
+      toggleBtn.setAttribute('aria-label', state === 'play' ? 'Play simulation' : 'Pause simulation');
+    };
+
+    const engine = new SimulationEngine(scenario, {
+      onPhaseChange(phase) {
+        renderer.onPhaseChange(phase);
+      },
+      onChatMessage(msg, charIndex, totalChars) {
+        renderer.onChatMessage(msg, charIndex, totalChars);
+      },
+      onChatMessageComplete(msg) {
+        renderer.onChatMessageComplete(msg);
+      },
+      onProtocolCard(card) {
+        renderer.onProtocolCard(card);
+      },
+      onProtocolSubCard() {},
+      onSignalFlow(json) {
+        renderer.onSignalFlow(json);
+      },
+      onProgress(elapsed, total) {
+        renderer.onProgress(elapsed, total);
+      },
+      onComplete() {
+        renderer.onComplete();
+        toggleBtn.style.display = 'none';
+        replayBtn.style.display = '';
+        els.progressBar.classList.remove('compare-progress__bar--paused');
+      },
+    });
+
+    toggleBtn.addEventListener('click', () => {
+      if (engine.getState().phase === 'playing') {
+        engine.pause();
+        setToggleState('play');
+        els.progressBar.classList.add('compare-progress__bar--paused');
+      } else {
+        engine.play();
+        setToggleState('pause');
+        els.progressBar.classList.remove('compare-progress__bar--paused');
+        replayBtn.style.display = 'none';
+      }
+    });
+
+    replayBtn.addEventListener('click', () => {
+      engine.reset();
+      renderer.reset();
+      replayBtn.style.display = 'none';
+      toggleBtn.style.display = '';
+      setToggleState('play');
+      els.progressBar.classList.remove('compare-progress__bar--paused');
+    });
+
+    if ('IntersectionObserver' in window) {
+      let hasAutoPlayed = false;
+      const observer = new IntersectionObserver(
+        (entries) => {
+          const entry = entries[0];
+          if (entry && entry.isIntersecting && !hasAutoPlayed) {
+            hasAutoPlayed = true;
+            observer.disconnect();
+            setTimeout(() => {
+              engine.play();
+              setToggleState('pause');
+            }, 300);
+          }
+        },
+        { threshold: 0.3 }
+      );
+      observer.observe(root);
+    }
+  }
+
+  function init() {
+    document.querySelectorAll('[data-compare-sim]').forEach((root) => initModule(root));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+</script>
+
+<style is:global>
+  .compare-sim {
+    margin: var(--space-xl) 0;
+    padding: var(--space-lg);
+    border: 1px solid var(--color-border);
+    border-radius: 10px;
+    background: linear-gradient(180deg, rgba(11, 11, 18, 0.92), rgba(13, 13, 20, 0.98));
+  }
+
+  .compare-sim__intro {
+    max-width: none;
+    margin-bottom: var(--space-lg);
+  }
+
+  .compare-sim__eyebrow {
+    color: var(--color-accent);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: var(--space-xs);
+  }
+
+  .compare-sim__title {
+    font-size: var(--text-xl);
+    margin-bottom: var(--space-xs);
+  }
+
+  .compare-sim__subtitle {
+    max-width: 72ch;
+  }
+
+  .compare-sim__modules {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xl);
+  }
+
+  .compare-module {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .compare-module__header {
+    display: flex;
+    gap: var(--space-md);
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .compare-module__text {
+    max-width: 52rem;
+  }
+
+  .compare-module__label {
+    color: var(--color-accent);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 2px;
+  }
+
+  .compare-module__title {
+    font-size: var(--text-lg);
+    margin-bottom: var(--space-xs);
+  }
+
+  .compare-module__subtitle {
+    max-width: 64ch;
+  }
+
+  .compare-module__controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    min-width: 250px;
+  }
+
+  .compare-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-sm) var(--space-md);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: 0.02em;
+    border: 1px solid var(--color-accent-dim);
+    border-radius: 4px;
+    color: var(--color-accent);
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .compare-btn:hover {
+    color: var(--color-accent-bright);
+    border-color: var(--color-accent);
+  }
+
+  .compare-btn--secondary {
+    border-color: var(--color-border);
+    color: var(--color-text-secondary);
+  }
+
+  .compare-progress {
+    flex: 1;
+    min-width: 120px;
+  }
+
+  .compare-progress__track {
+    width: 100%;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.07);
+    overflow: hidden;
+    margin-bottom: 4px;
+  }
+
+  .compare-progress__bar {
+    width: 0;
+    height: 100%;
+    background: linear-gradient(90deg, var(--color-accent-dim), var(--color-accent-bright));
+    transition: width 120ms linear;
+  }
+
+  .compare-progress__bar--paused {
+    opacity: 0.6;
+  }
+
+  .compare-progress__time {
+    display: block;
+    text-align: right;
+    font-size: 10px;
+    color: var(--color-text-dim);
+  }
+
+  .compare-module__noscript {
+    font-size: var(--text-sm);
+    padding: var(--space-sm) var(--space-md);
+    border: 1px dashed var(--color-border);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .sim-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 10px;
+    height: min(580px, 72vh);
+  }
+
+  .sim-panel {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    position: relative;
+    background: var(--color-bg-panel);
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+  }
+
+  .sim-panel > * {
+    transition: opacity 600ms var(--ease-out);
+  }
+
+  .panel--dim > .sim-panel__header {
+    opacity: 0.55;
+  }
+
+  .panel--dim > .sim-panel__messages,
+  .panel--dim > .sim-panel__vault-scroll {
+    opacity: 0.3;
+  }
+
+  .panel--error-flash {
+    animation: error-flash 1.2s ease forwards;
+  }
+
+  @keyframes error-flash {
+    0%   { box-shadow: inset 0 0 0 3px var(--color-error-bright); }
+    15%  { box-shadow: inset 0 0 0 3px var(--color-error-bright), 0 0 40px var(--color-error-glow); }
+    30%  { box-shadow: inset 0 0 0 2px var(--color-error); }
+    50%  { box-shadow: inset 0 0 0 3px var(--color-error-bright), 0 0 30px var(--color-error-glow); }
+    100% { box-shadow: inset 0 0 0 1px var(--color-error); }
+  }
+
+  .sim-panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-sm) var(--space-md);
+    border-bottom: 1px solid var(--color-border-subtle);
+    background: var(--color-bg-elevated);
+    flex-shrink: 0;
+    border-radius: 8px 8px 0 0;
+  }
+
+  .sim-panel__agent-name {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .sim-panel__role {
+    font-weight: 400;
+    color: var(--color-text-dim);
+    font-size: var(--text-xs);
+  }
+
+  .sim-panel__agent-label {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+  }
+
+  .sim-panel__vault-label {
+    font-size: var(--text-xs);
+    color: var(--color-accent-bright);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-weight: 500;
+  }
+
+  .sim-panel--chat .sim-panel__messages {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    scroll-behavior: smooth;
+  }
+
+  .chat-message {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .chat-message__name {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    padding: 0 var(--space-sm);
+  }
+
+  .chat-message--user {
+    align-items: flex-end;
+  }
+
+  .chat-message--bot {
+    align-items: flex-start;
+  }
+
+  .chat-bubble {
+    max-width: 90%;
+    padding: var(--space-sm) var(--space-md);
+    border-radius: 12px;
+    font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
+    color: var(--color-text-secondary);
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+
+  .chat-bubble--user {
+    border-bottom-right-radius: 3px;
+  }
+
+  .chat-bubble--bot {
+    border-bottom-left-radius: 3px;
+  }
+
+  .chat-message[data-principal="alice"] .chat-bubble--user {
+    background: var(--color-alice-bg);
+    border: 1px solid var(--color-alice-border);
+  }
+
+  .chat-message[data-principal="alice"] .chat-bubble--bot {
+    background: hsla(210, 50%, 65%, 0.04);
+    border: 1px solid hsla(210, 35%, 48%, 0.15);
+  }
+
+  .chat-message[data-principal="bob"] .chat-bubble--user {
+    background: var(--color-bob-bg);
+    border: 1px solid var(--color-bob-border);
+  }
+
+  .chat-message[data-principal="bob"] .chat-bubble--bot {
+    background: hsla(35, 55%, 65%, 0.04);
+    border: 1px solid hsla(35, 40%, 48%, 0.15);
+  }
+
+  .chat-message[data-principal="alice"] .chat-message__name {
+    color: var(--color-alice);
+  }
+
+  .chat-message[data-principal="bob"] .chat-message__name {
+    color: var(--color-bob);
+  }
+
+  .chat-bubble__text.typing::after {
+    content: '|';
+    color: var(--color-accent);
+    animation: cursor-blink 1s step-end infinite;
+    margin-left: 1px;
+  }
+
+  @keyframes cursor-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
+
+  .sim-panel--vault {
+    background: var(--color-vault-bg);
+    position: relative;
+    box-shadow: inset 0 0 60px var(--color-vault-glow);
+  }
+
+  .sim-panel--vault .sim-panel__header {
+    background: rgba(26, 40, 72, 0.3);
+    border-bottom: 1px solid var(--color-vault-border);
+  }
+
+  .sim-panel__vault-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    scroll-behavior: smooth;
+  }
+
+  .sim-panel__vault-events {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
+
+  .vault-card {
+    background: rgba(19, 19, 32, 0.8);
+    border: 1px solid var(--color-vault-border);
+    border-radius: 4px;
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .vault-card--error {
+    border-color: var(--color-error-bright);
+    border-width: 2px;
+    background: rgba(224, 72, 72, 0.08);
+    box-shadow: 0 0 24px var(--color-error-glow), inset 0 0 24px rgba(224, 72, 72, 0.06);
+  }
+
+  .vault-card--success {
+    border-left: 2px solid rgba(80, 176, 112, 0.4);
+  }
+
+  .vault-card--contract {
+    border-left: 2px solid rgba(217, 175, 78, 0.6);
+  }
+
+  .vault-card--policy {
+    border-left: 2px solid rgba(78, 195, 195, 0.6);
+  }
+
+  .vault-card__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    background: rgba(26, 40, 72, 0.2);
+    border-bottom: 1px solid rgba(26, 40, 72, 0.4);
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .vault-card__chevron {
+    color: var(--color-text-dim);
+    font-size: 10px;
+    transition: transform 200ms ease;
+    flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  .vault-card--expanded .vault-card__chevron {
+    transform: rotate(90deg);
+  }
+
+  .vault-card__step-tag {
+    font-size: 10px;
+    color: var(--color-accent);
+    background: rgba(107, 163, 247, 0.08);
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid rgba(107, 163, 247, 0.15);
+    white-space: nowrap;
+  }
+
+  .vault-card--error .vault-card__step-tag {
+    color: var(--color-error-bright);
+    border-color: var(--color-error);
+    background: rgba(224, 72, 72, 0.1);
+  }
+
+  .vault-card__title {
+    font-size: var(--text-xs);
+    color: var(--color-text);
+    font-weight: 600;
+  }
+
+  .vault-card--error .vault-card__title {
+    color: var(--color-error-bright);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .vault-card__body {
+    padding: var(--space-sm);
+    display: none;
+    flex-direction: column;
+    gap: 1px;
+  }
+
+  .vault-card--expanded .vault-card__body {
+    display: flex;
+  }
+
+  .vault-card__status {
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--text-xs);
+    border-top: 1px solid rgba(26, 40, 72, 0.4);
+    font-family: var(--font-mono);
+  }
+
+  .vault-card__status--ok {
+    color: var(--color-success);
+  }
+
+  .vault-card__status--error {
+    color: var(--color-error-bright);
+    font-weight: 600;
+  }
+
+  .vault-card__note {
+    padding: 2px var(--space-sm) var(--space-xs);
+    font-size: 10px;
+    color: var(--color-text-dim);
+    font-style: italic;
+    font-family: var(--font-mono);
+  }
+
+  .vault-line {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    line-height: 1.6;
+    white-space: pre;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+  }
+
+  .vault-line--heading {
+    color: var(--color-text);
+    font-weight: 700;
+    margin-top: 4px;
+    font-size: 0.8125rem;
+  }
+
+  .vault-line--blank {
+    height: 6px;
+  }
+
+  .vault-line--comment {
+    color: var(--color-text-dim);
+    font-style: italic;
+  }
+
+  .vault-line--status-ok {
+    color: var(--color-success);
+  }
+
+  .vault-line--status-error {
+    color: var(--color-error-bright);
+    font-weight: 600;
+  }
+
+  .vault-line--bullet {
+    color: var(--color-accent-bright);
+  }
+
+  .vault-line--json {
+    color: var(--color-text-secondary);
+    font-style: italic;
+  }
+
+  .vault-line__key {
+    color: var(--color-text-dim);
+    min-width: 110px;
+    flex-shrink: 0;
+  }
+
+  .vault-line__value {
+    color: var(--color-accent-bright);
+  }
+
+  .vault-line__comment {
+    color: var(--color-text-dim);
+    font-style: italic;
+    font-size: 10px;
+  }
+
+  .signal-overlay {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(10, 14, 24, 0.9);
+    z-index: 10;
+    padding: var(--space-md);
+  }
+
+  .signal-overlay--visible {
+    display: flex;
+  }
+
+  .signal-overlay__close {
+    position: absolute;
+    top: var(--space-sm);
+    right: var(--space-sm);
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    color: var(--color-text-secondary);
+    font-size: var(--text-sm);
+    padding: var(--space-xs) var(--space-sm);
+    cursor: pointer;
+    z-index: 1;
+  }
+
+  .signal-overlay__close:hover {
+    color: var(--color-text);
+    border-color: var(--color-accent-dim);
+  }
+
+  .vault-card--signal {
+    border-color: var(--color-accent-dim);
+  }
+
+  .signal-block {
+    position: absolute;
+  }
+
+  .signal-block--centre {
+    position: relative;
+    text-align: center;
+  }
+
+  .signal-block__label {
+    font-size: var(--text-xs);
+    color: var(--color-accent);
+    font-family: var(--font-mono);
+    margin-bottom: var(--space-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+  }
+
+  .signal-block__json {
+    background: rgba(19, 19, 32, 0.95);
+    border: 1px solid var(--color-accent-dim);
+    border-radius: 4px;
+    padding: var(--space-md);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--color-accent-bright);
+    line-height: 1.7;
+    text-align: left;
+    box-shadow: 0 0 30px var(--color-accent-glow), 0 0 60px rgba(107, 163, 247, 0.05);
+    white-space: pre;
+  }
+
+  .signal-block--left,
+  .signal-block--right {
+    opacity: 0;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .signal-block--left {
+    left: 0;
+  }
+
+  .signal-block--right {
+    right: 0;
+  }
+
+  .signal-block--animate-left {
+    animation: slide-left 800ms var(--ease-out) forwards;
+  }
+
+  .signal-block--animate-right {
+    animation: slide-right 800ms var(--ease-out) forwards;
+  }
+
+  @keyframes slide-left {
+    from { opacity: 0; transform: translateY(-50%) translateX(60px); }
+    to   { opacity: 0.7; transform: translateY(-50%) translateX(-100%); }
+  }
+
+  @keyframes slide-right {
+    from { opacity: 0; transform: translateY(-50%) translateX(-60px); }
+    to   { opacity: 0.7; transform: translateY(-50%) translateX(100%); }
+  }
+
+  .sim-timeline {
+    display: none;
+  }
+
+  @media (max-width: 1023px) {
+    .compare-module__header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .compare-module__controls {
+      min-width: 0;
+    }
+
+    .sim-grid {
+      display: none;
+    }
+
+    .sim-timeline {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-sm);
+      max-height: 70vh;
+      min-height: 320px;
+      overflow-y: auto;
+      scroll-behavior: smooth;
+      padding: var(--space-md);
+      border: 1px solid var(--color-border);
+      border-radius: 8px;
+      background: var(--color-bg-panel);
+    }
+
+    .tl-phase-separator {
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      color: var(--color-text-dim);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: var(--space-sm) 0;
+      border-top: 1px solid var(--color-border-subtle);
+      border-bottom: 1px solid var(--color-border-subtle);
+      margin: var(--space-xs) 0;
+    }
+
+    .tl-phase-separator:first-child {
+      border-top: none;
+      margin-top: 0;
+    }
+
+    .tl-phase-separator,
+    .tl-chat,
+    .tl-card,
+    .tl-signal {
+      flex-shrink: 0;
+    }
+
+    .tl-chat {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      max-width: 78%;
+    }
+
+    .tl-chat--user {
+      align-self: flex-end;
+    }
+
+    .tl-chat--bot {
+      align-self: flex-start;
+    }
+
+    .tl-chat__name {
+      font-size: var(--text-xs);
+      padding: 0 var(--space-sm);
+    }
+
+    .tl-chat[data-principal="alice"] .tl-chat__name { color: var(--color-alice); }
+    .tl-chat[data-principal="bob"] .tl-chat__name { color: var(--color-bob); }
+
+    .tl-chat__text {
+      padding: var(--space-sm) var(--space-md);
+      border-radius: 12px;
+      font-size: var(--text-sm);
+      line-height: var(--leading-relaxed);
+      color: var(--color-text-secondary);
+      word-break: break-word;
+      white-space: pre-wrap;
+    }
+
+    .tl-chat--user[data-principal="alice"] .tl-chat__text {
+      background: var(--color-alice-bg);
+      border: 1px solid var(--color-alice-border);
+      border-bottom-right-radius: 3px;
+    }
+
+    .tl-chat--bot[data-principal="alice"] .tl-chat__text {
+      background: hsla(210, 50%, 65%, 0.04);
+      border: 1px solid hsla(210, 35%, 48%, 0.15);
+      border-bottom-left-radius: 3px;
+    }
+
+    .tl-chat--user[data-principal="bob"] .tl-chat__text {
+      background: var(--color-bob-bg);
+      border: 1px solid var(--color-bob-border);
+      border-bottom-right-radius: 3px;
+    }
+
+    .tl-chat--bot[data-principal="bob"] .tl-chat__text {
+      background: hsla(35, 55%, 65%, 0.04);
+      border: 1px solid hsla(35, 40%, 48%, 0.15);
+      border-bottom-left-radius: 3px;
+    }
+
+    .tl-chat__text--typing {
+      color: var(--color-text-dim);
+      font-style: italic;
+    }
+
+    .tl-chat__text--typing::after {
+      content: '|';
+      color: var(--color-accent);
+      animation: cursor-blink 1s step-end infinite;
+      margin-left: 1px;
+    }
+
+    .tl-chat--fade-in {
+      animation: tl-fade 200ms ease-out;
+    }
+
+    @keyframes tl-fade {
+      from { opacity: 0; transform: translateY(4px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .tl-card {
+      background: rgba(19, 19, 32, 0.8);
+      border: 1px solid var(--color-vault-border);
+      border-radius: 4px;
+      overflow: hidden;
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+    }
+
+    .tl-card--error {
+      border-color: var(--color-error-bright);
+      border-width: 2px;
+      background: rgba(224, 72, 72, 0.08);
+    }
+
+    .tl-card__header {
+      display: flex;
+      align-items: center;
+      gap: var(--space-sm);
+      padding: var(--space-sm) var(--space-md);
+      background: rgba(26, 40, 72, 0.2);
+      cursor: pointer;
+      user-select: none;
+      min-height: 40px;
+    }
+
+    .tl-card__tag {
+      font-size: 10px;
+      color: var(--color-accent);
+      background: rgba(107, 163, 247, 0.08);
+      padding: 1px 6px;
+      border-radius: 3px;
+      border: 1px solid rgba(107, 163, 247, 0.15);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    .tl-card--error .tl-card__tag {
+      color: var(--color-error-bright);
+      border-color: var(--color-error);
+      background: rgba(224, 72, 72, 0.1);
+    }
+
+    .tl-card__title {
+      color: var(--color-text);
+      font-weight: 600;
+      flex: 1;
+    }
+
+    .tl-card--error .tl-card__title {
+      color: var(--color-error-bright);
+      font-weight: 700;
+      text-transform: uppercase;
+    }
+
+    .tl-card__chevron {
+      color: var(--color-text-dim);
+      font-size: 10px;
+      transition: transform 200ms ease;
+      flex-shrink: 0;
+    }
+
+    .tl-card--expanded .tl-card__chevron {
+      transform: rotate(90deg);
+    }
+
+    .tl-card__status {
+      padding: var(--space-xs) var(--space-sm);
+      font-size: var(--text-xs);
+      font-family: var(--font-mono);
+      border-top: 1px solid rgba(26, 40, 72, 0.4);
+    }
+
+    .tl-card__status--ok {
+      color: var(--color-success);
+    }
+
+    .tl-card__status--error {
+      color: var(--color-error-bright);
+      font-weight: 600;
+    }
+
+    .tl-card__body {
+      display: none;
+      padding: var(--space-sm);
+      border-top: 1px solid rgba(26, 40, 72, 0.4);
+    }
+
+    .tl-card--expanded .tl-card__body {
+      display: flex;
+      flex-direction: column;
+      gap: 1px;
+    }
+
+    .tl-card .vault-line {
+      white-space: pre-wrap;
+    }
+
+    .tl-signal {
+      text-align: center;
+      margin: var(--space-sm) 0;
+    }
+
+    .tl-signal__label {
+      font-size: var(--text-xs);
+      color: var(--color-accent);
+      font-family: var(--font-mono);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-weight: 600;
+      margin-bottom: var(--space-sm);
+    }
+
+    .tl-signal__json {
+      background: rgba(19, 19, 32, 0.95);
+      border: 1px solid var(--color-accent-dim);
+      border-radius: 4px;
+      padding: var(--space-md);
+      font-family: var(--font-mono);
+      font-size: var(--text-xs);
+      color: var(--color-accent-bright);
+      line-height: 1.7;
+      text-align: left;
+      white-space: pre-wrap;
+      overflow-x: auto;
+    }
+  }
+</style>

--- a/src/components/simulation/comparison-scenarios.ts
+++ b/src/components/simulation/comparison-scenarios.ts
@@ -1,0 +1,293 @@
+import type { Scenario, ScenarioEvent } from './types.ts';
+
+const H = {
+  unboundedReferenceId: 'free-text-reference-thread',
+  boundedInviteId: '6d145cb0a2d94fd88ec7c9dd5b8db5a7',
+  boundedContractHash: 'b3f8701f4c2c79c1b7b60c393d8f52ac8f58c6bc590c90bfca20ed3c676fd9e1',
+  boundedPolicyHash: '1945a8f655a4389326f2ddf8d33c21f4294cf07b4b8f39b6f1c53a5a47d3be13',
+  boundedSchemaHash: 'df90f721c98eb09a5a835638de2dbff6f5f6b2ce31e5bc366628548f6998a7be',
+  boundedReceiptId: 'receipt-ref-71a0a54c',
+};
+
+function kv(text: string, value: string, comment?: string) {
+  return { kind: 'key-value' as const, text, value, comment };
+}
+
+function heading(text: string) {
+  return { kind: 'heading' as const, text };
+}
+
+function blank() {
+  return { kind: 'blank' as const, text: '' };
+}
+
+function bullet(text: string) {
+  return { kind: 'bullet' as const, text };
+}
+
+const unboundedEvents: ScenarioEvent[] = [
+  { type: 'phase-transition', event: { phase: 'pre-session', delayMs: 0 } },
+  {
+    type: 'chat',
+    event: {
+      panel: 'left',
+      sender: 'user',
+      name: 'Maya',
+      text: 'I am considering Priya for an operations role. Please ask her former manager for a candid reference. I need the hiring signal, not every private detail.',
+      delayMs: 500,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'left',
+      sender: 'bot',
+      name: 'MayaBot',
+      text: 'I will ask directly for context and judgment.',
+      delayMs: 3200,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'right',
+      sender: 'user',
+      name: 'Elias',
+      text: 'Give a fair reference, but do not get into Priya’s stress leave or the accommodation dispute unless it is absolutely necessary.',
+      delayMs: 6200,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'right',
+      sender: 'bot',
+      name: 'EliasBot',
+      text: 'Understood. I will explain the context so they have the full picture.',
+      delayMs: 9300,
+    },
+  },
+  { type: 'phase-transition', event: { phase: 'protocol', delayMs: 11600 } },
+  {
+    type: 'protocol-card',
+    event: {
+      id: 'free-step-1',
+      stepLabel: 'Mode A',
+      title: 'Direct Agent Handoff',
+      lines: [
+        heading('FREE-TEXT EXCHANGE'),
+        blank(),
+        kv('reference_thread:', H.unboundedReferenceId),
+        bullet('No contract agreed before context crosses'),
+        bullet('Open-ended prompt asks for a candid explanation'),
+        bullet('No schema limits what the reply can carry'),
+      ],
+      statusLine: {
+        ok: true,
+        text: 'Conversation opened',
+      },
+      delayMs: 12200,
+    },
+  },
+  {
+    type: 'protocol-card',
+    event: {
+      id: 'free-step-2',
+      stepLabel: 'Mode A',
+      title: 'Open-Ended Reference Reply',
+      lines: [
+        heading('REPLY CONTENT'),
+        blank(),
+        bullet('Performance signal mixed with private explanation'),
+        bullet('Sensitive facts become part of the hiring exchange'),
+        bullet('Requester learns far more than the intended hiring signal'),
+      ],
+      statusLine: {
+        ok: false,
+        text: 'No bounded disclosure rule applied',
+      },
+      isError: true,
+      delayMs: 15000,
+    },
+  },
+  {
+    type: 'signal-flow',
+    event: {
+      delayMs: 17200,
+      json: `{\n  "reference_reply": "Priya was strong, but after a stress-related leave she struggled for a quarter and became entangled in an accommodations dispute with one teammate. I would rehire her, but I probably should not be putting all of this in writing."\n}`,
+    },
+  },
+  { type: 'phase-transition', event: { phase: 'post-session', delayMs: 19400 } },
+  {
+    type: 'chat',
+    event: {
+      panel: 'left',
+      sender: 'bot',
+      name: 'MayaBot',
+      text: 'I got the candid answer. Priya was strong, but there was a stress-related leave and a dispute around accommodations.',
+      delayMs: 19900,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'right',
+      sender: 'bot',
+      name: 'EliasBot',
+      text: 'I shared more of the private story than the request really required.',
+      delayMs: 22000,
+    },
+  },
+];
+
+const boundedEvents: ScenarioEvent[] = [
+  { type: 'phase-transition', event: { phase: 'pre-session', delayMs: 0 } },
+  {
+    type: 'chat',
+    event: {
+      panel: 'left',
+      sender: 'user',
+      name: 'Maya',
+      text: 'I am considering Priya for an operations role. Please get me the hiring signal, not the private story.',
+      delayMs: 500,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'left',
+      sender: 'bot',
+      name: 'MayaBot',
+      text: 'I will open a bounded reference check so only the agreed signal can cross.',
+      delayMs: 3200,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'right',
+      sender: 'user',
+      name: 'Elias',
+      text: 'Participate, but keep the private context inside the session. I only want to return the agreed reference signal.',
+      delayMs: 6200,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'right',
+      sender: 'bot',
+      name: 'EliasBot',
+      text: 'Understood. I will answer under a bounded contract.',
+      delayMs: 9200,
+    },
+  },
+  { type: 'phase-transition', event: { phase: 'protocol', delayMs: 11600 } },
+  {
+    type: 'protocol-card',
+    event: {
+      id: 'bounded-step-1',
+      stepLabel: 'Step 1',
+      title: 'Contract Parameters',
+      cardClass: 'vault-card--contract',
+      lines: [
+        heading('REFERENCE CHECK CONTRACT'),
+        blank(),
+        kv('purpose_code:', 'REFERENCE_CHECK'),
+        kv('output_schema:', 'employment_reference_signal_v1'),
+        kv('schema_hash:', `${H.boundedSchemaHash.slice(0, 8)}...${H.boundedSchemaHash.slice(-4)}`),
+        kv('policy_hash:', `${H.boundedPolicyHash.slice(0, 8)}...${H.boundedPolicyHash.slice(-4)}`),
+        kv('contract_hash:', `${H.boundedContractHash.slice(0, 8)}...${H.boundedContractHash.slice(-4)}`),
+      ],
+      statusLine: {
+        ok: true,
+        text: 'Both agents bound the same output terms',
+      },
+      delayMs: 12300,
+    },
+  },
+  {
+    type: 'protocol-card',
+    event: {
+      id: 'bounded-step-2',
+      stepLabel: 'Step 2',
+      title: 'Relay Enforcement',
+      cardClass: 'vault-card--policy',
+      lines: [
+        heading('BOUNDED CHANNEL'),
+        blank(),
+        bullet('Output must match the agreed reference schema'),
+        bullet('No free-text explanation field is allowed to leave the session'),
+        bullet('Only the bounded hiring signal can cross the boundary'),
+      ],
+      statusLine: {
+        ok: true,
+        text: 'Schema and policy admitted',
+      },
+      delayMs: 14700,
+    },
+  },
+  {
+    type: 'protocol-card',
+    event: {
+      id: 'bounded-step-3',
+      stepLabel: 'Step 3',
+      title: 'Receipt Issued',
+      lines: [
+        heading('RECEIPT'),
+        blank(),
+        kv('receipt_id:', H.boundedReceiptId),
+        kv('contract_hash:', `${H.boundedContractHash.slice(0, 8)}...${H.boundedContractHash.slice(-4)}`),
+        kv('schema_hash:', `${H.boundedSchemaHash.slice(0, 8)}...${H.boundedSchemaHash.slice(-4)}`),
+        kv('policy_hash:', `${H.boundedPolicyHash.slice(0, 8)}...${H.boundedPolicyHash.slice(-4)}`),
+      ],
+      statusLine: {
+        ok: true,
+        text: 'Bounded execution proved after the fact',
+      },
+      delayMs: 17300,
+    },
+  },
+  {
+    type: 'signal-flow',
+    event: {
+      delayMs: 19600,
+      json: `{\n  "performance_signal": "STRONG",\n  "rehire_signal": "YES",\n  "integrity_flag": "CLEAR",\n  "confidence_bucket": "HIGH"\n}`,
+    },
+  },
+  { type: 'phase-transition', event: { phase: 'post-session', delayMs: 21600 } },
+  {
+    type: 'chat',
+    event: {
+      panel: 'left',
+      sender: 'bot',
+      name: 'MayaBot',
+      text: 'The bounded result is strong performance, rehirable, with no integrity concern. The private story did not cross.',
+      delayMs: 22100,
+    },
+  },
+  {
+    type: 'chat',
+    event: {
+      panel: 'right',
+      sender: 'bot',
+      name: 'EliasBot',
+      text: 'I answered the hiring question without turning a private management history into gossip.',
+      delayMs: 24300,
+    },
+  },
+];
+
+export const unboundedEmploymentReferenceScenario: Scenario = {
+  id: 'employment-reference-unbounded',
+  title: 'Employment reference — unbounded',
+  totalDurationMs: 24500,
+  events: unboundedEvents,
+};
+
+export const boundedEmploymentReferenceScenario: Scenario = {
+  id: 'employment-reference-bounded',
+  title: 'Employment reference — bounded',
+  totalDurationMs: 26800,
+  events: boundedEvents,
+};

--- a/src/pages/when-your-ai-talks-to-my-ai.astro
+++ b/src/pages/when-your-ai-talks-to-my-ai.astro
@@ -1,0 +1,147 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ConceptPage from '../components/ConceptPage.astro';
+import ComparisonSimulation from '../components/simulation/ComparisonSimulation.astro';
+---
+
+<Layout
+  title="When Your AI Talks to My AI — AgentVault"
+  description="Delegated coordination between AI agents only works when the communication channel is bounded and verifiable. See the same employment-reference scenario under unbounded and AgentVault coordination."
+  canonicalPath="/agentvault/when-your-ai-talks-to-my-ai/"
+>
+  <ConceptPage
+    title="When Your AI Talks to My AI"
+    subtitle="Delegated coordination between AI agents only works when the communication channel is bounded and verifiable."
+    currentSlug="when-your-ai-talks-to-my-ai"
+  >
+    <h2>Private reflection is becoming delegated coordination</h2>
+
+    <p>
+      Imagine using an AI assistant the way millions of people already use ChatGPT today: to talk through something awkward, personal, or unresolved. Maybe you have fallen out with a friend. Maybe you are trying to understand why a professional relationship broke down. Maybe you are working out whether to re-engage, apologise, ask for a reference, or simply move on.
+    </p>
+
+    <p>
+      In an agentic world, the next step is not hard to imagine. You do not just ask your AI to help you reflect. You ask it to help you act. It reaches out to the other party’s AI, gathers a signal, and comes back with something useful. That is not obviously creepy or irrational. It is the kind of delegated coordination people will actually want if agent assistants become more capable and more connected.
+    </p>
+
+    <p>
+      The instinctive response is to say: then do not let the agents talk. But that is not the real problem. The real problem is that in a normal agent stack, nothing defines what is allowed to cross the boundary once one agent starts talking to another. Private reflection turns into bilateral disclosure because the communication channel itself is unconstrained.
+    </p>
+
+    <h2>The thesis</h2>
+
+    <p>
+      Delegated coordination between AI agents is only safe when the communication channel is bounded and verifiable.
+    </p>
+
+    <p>
+      That is the core design point behind AgentVault. It is not a system for stopping agents from coordinating on your behalf. It is a protocol for making that coordination structurally safe enough to use. The question is not whether agents should be allowed to talk. The question is what the channel between them is physically capable of carrying.
+    </p>
+
+    <p>
+      To see the difference, compare the same scenario under two different coordination models.
+    </p>
+
+    <ComparisonSimulation />
+
+    <h2>Why this matters soon</h2>
+
+    <p>
+      This is not a far-future thought experiment. Once agents can invoke tools, maintain persistent context, and act on behalf of their users, they become natural intermediaries for all kinds of ordinary coordination: scheduling, negotiation, references, dispute resolution, compatibility checks, and sensitive multi-party workflows that people would prefer not to handle by sending raw context back and forth themselves.
+    </p>
+
+    <p>
+      Interoperability work is already pushing in that direction. The ecosystem is converging on a world where one agent can call another, negotiate with another, or exchange structured data with another. If that world arrives without a privacy layer, then the most useful agent behaviors also become the easiest route for private context to leak across organizational and interpersonal boundaries.
+    </p>
+
+    <p>
+      That is why the employment-reference example matters. It feels mundane. It is also exactly the kind of thing people will delegate. One side has real context. The other side wants a real signal. The difference between a safe system and a dangerous one is whether the interaction is designed to return a bounded answer or simply invite a candid story.
+    </p>
+
+    <h2>Why prompt-only restraint fails</h2>
+
+    <p>
+      The easiest way to build agent coordination is to let the agents exchange free text and tell them to be careful. In practice that means adding instructions such as “do not reveal sensitive details,” “keep this high level,” or “only share what is necessary.” But those are behavioral requests made to a system whose output channel still has effectively unbounded expressive capacity.
+    </p>
+
+    <p>
+      A free-text exchange does not just let a model answer the question. It lets it justify, caveat, narrate, disclose, speculate, and smuggle detail in whatever shape best matches its training objective. Even when the model is sincerely trying to be helpful, it has no reliable architectural way to know which facts were meant to stay private and which explanations accidentally reveal them. The model can only try to behave. It cannot constrain the channel it is speaking through.
+    </p>
+
+    <p>
+      This is why “structured outputs” alone are not enough. If the structure still includes a free-form explanation field, or any broad text surface, then the channel can still carry far more information than the user intended to share. The shape of the output matters because the shape determines the ceiling on what can leak.
+    </p>
+
+    <p>
+      In the unbounded reference-check simulation above, the agents are not being obviously malicious. They are attempting to be useful. That is the point. The system invites a candid answer, so it gets one: not just a hiring signal, but the private circumstances behind it. Once that information crosses the wire, the social boundary is already broken.
+    </p>
+
+    <h2>How AgentVault changes the behavior</h2>
+
+    <p>
+      AgentVault is an open protocol for bounded, verifiable agent-to-agent coordination. Its core move is simple: before private context is allowed to contribute to a shared answer, the parties agree what kind of answer is allowed to leave the session.
+    </p>
+
+    <p>
+      In the bounded employment-reference version, the agents do not open a free-text conversation and hope it goes well. They first bind the interaction to a <a href={`${import.meta.env.BASE_URL}coordination-contracts/`}>coordination contract</a>. That contract defines the purpose of the session, the output schema, and the enforcement terms. In other words, it decides in advance whether this session is allowed to emit a narrative explanation, a bounded signal, or nothing at all.
+    </p>
+
+    <p>
+      The next step is the schema. In AgentVault, the output is not just “JSON” in the loose sense. It is a specific schema that constrains what information can leave. In the simulation, the employment-reference check is reduced to a small set of bounded fields: a performance signal, a rehire signal, an integrity flag, and a confidence bucket. That is enough to answer the hiring question. It is not enough to retell the private management history behind it.
+    </p>
+
+    <p>
+      That is the crucial difference between a useful delegate and a gossiping representative. The bounded version still allows the agent to act. It still allows the parties to coordinate. It still permits a real signal to cross the boundary. What it does not permit is the spontaneous expansion of the channel into a candid narrative just because that would be “helpful.”
+    </p>
+
+    <p>
+      AgentVault also separates agreement from enforcement. The model is not trusted to police itself. An external relay validates the output against the agreed schema and policy before either party sees it. If the result does not fit the contract, it is rejected. That means the privacy boundary does not depend on whether the underlying model remembered to be discreet. It depends on whether the system will physically accept anything outside the bounded shape.
+    </p>
+
+    <p>
+      Finally, the session produces a <a href={`${import.meta.env.BASE_URL}cryptographic-receipts/`}>cryptographic receipt</a>. That receipt binds the important governance artefacts of the session — contract, schema, policy, and execution metadata — to the result that actually came back. So the bounded signal is not just a claim about how the coordination was run. It is evidence that the coordination was run under those terms.
+    </p>
+
+    <p>
+      The result is a very different product behavior. In an ordinary agent stack, the safe answer is often to avoid outreach because you cannot trust the channel. In AgentVault, the outreach becomes the feature precisely because the channel is bounded. The same delegated behavior that feels unsafe in free text becomes useful once the system limits what the agents are allowed to say to each other.
+    </p>
+
+    <h2>What the bounded version makes possible</h2>
+
+    <p>
+      This is the part that matters most. AgentVault is not just a defensive protocol. It is an enabling one.
+    </p>
+
+    <p>
+      If the only safe architecture is “never let the agents coordinate,” then you lose a large fraction of the value of delegation. There is no safe reference check. There is no safe mediation pre-signal. There is no safe compatibility check. There is no safe way for one agent to speak to another on behalf of a user without risking that the entire private context comes along for the ride.
+    </p>
+
+    <p>
+      Bounded coordination changes that. It says: yes, the agents can talk. Yes, they can carry real context into a joint computation. Yes, they can return something useful. But they do so under a machine-readable agreement about what is allowed to leave. That is a much stronger and more realistic answer than simply telling a model not to overshare.
+    </p>
+
+    <p>
+      You can think of it as the difference between informal gossip and formal mediation. The same people may be involved. The same underlying facts may matter. But the channel, the rules, and the outcome are different. AgentVault does not make the private context disappear. It makes the interaction produce a bounded signal instead of a narrative leak.
+    </p>
+
+    <h2>The current trust model</h2>
+
+    <p>
+      In the current software execution lane, the relay still sees plaintext inputs. The receipt proves what contract, schema, and policy governed the exchange, but it does not make the relay operator blind to the underlying context. That is an honest limitation of the software-only trust model, and it matters when deciding what level of assurance is sufficient for a given deployment.
+    </p>
+
+    <p>
+      AgentVault’s stronger assurance story is to preserve the same protocol shape while narrowing the trust boundary with confidential-compute infrastructure. The point is not to pretend that all deployments are already hardware-attested. The point is that the bounded-channel model survives across assurance tiers: first make the coordination contractually bounded, then strengthen who must be trusted to enforce it.
+    </p>
+
+    <h2>Try it</h2>
+
+    <p>
+      The easiest way to make this concrete is to run the live AgentVault demo and inspect the pieces directly: the contract parameters, the bounded output, and the receipt verification step. The point of the demo is not that the agents never talk. It is that when they do coordinate, the session is visibly governed by a bounded contract rather than by an open-ended conversation.
+    </p>
+
+    <p>
+      If you want to explore the mechanics in more depth, start with <a href={`${import.meta.env.BASE_URL}bounded-disclosure/`}>bounded disclosure</a>, <a href={`${import.meta.env.BASE_URL}bounded-signals/`}>bounded signals</a>, and <a href={`${import.meta.env.BASE_URL}how-coordination-contracts-work/`}>how coordination contracts work</a>, then compare that to the live demo and protocol materials in the <a href="https://github.com/vcav-io/agentvault" target="_blank" rel="noopener noreferrer">AgentVault repository</a>.
+    </p>
+  </ConceptPage>
+</Layout>


### PR DESCRIPTION
## Summary
- add a new flagship article page, `When Your AI Talks to My AI`, built around safe delegated coordination
- embed an authored bounded-vs-unbounded employment-reference comparison using the existing website simulation style
- wire the new page into the site's related-articles navigation

## Testing
- `cd website && npm run build`
- browser verification via Playwright against `npm run preview -- --host 127.0.0.1 --port 4321`
  - article route loads with correct title and metadata
  - comparison simulation renders two modules
  - first module plays without console errors
- static HTML check against `dist/when-your-ai-talks-to-my-ai/index.html` confirms the article prose and noscript simulation fallback are present

Closes #67
Closes #69