### PR TITLE
feat: add internal links from homepage to concept/article pages

### DIFF
--- a/src/components/ConceptPage.astro
+++ b/src/components/ConceptPage.astro
@@ -1,5 +1,6 @@
 ---
 import AVMark from './icons/AVMark.astro';
+import SiteFooter from './SiteFooter.astro';
 
 interface Props {
   title: string;
@@ -108,13 +109,7 @@ const relatedArticles = articles.filter(a => a.slug !== currentSlug);
 </nav>
 )}
 
-<footer class="site-footer">
-  <div class="container">
-    <p class="text-dim" style="font-size: var(--text-sm);">
-      vcav.io · <a href="mailto:contact@vcav.io" class="footer-link">contact@vcav.io</a>
-    </p>
-  </div>
-</footer>
+<SiteFooter />
 
 <style>
   .top-bar {
@@ -406,18 +401,4 @@ const relatedArticles = articles.filter(a => a.slug !== currentSlug);
     }
   }
 
-  .site-footer {
-    padding: var(--space-2xl) 0;
-    border-top: 1px solid var(--color-border-subtle);
-  }
-
-  .footer-link {
-    color: var(--color-text-dim);
-    text-decoration: none;
-    transition: color var(--duration-fast) var(--ease-out);
-  }
-
-  .footer-link:hover {
-    color: var(--color-accent);
-  }
 </style>

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -16,7 +16,6 @@ const articles = [
   { slug: 'a2a-and-agentvault', label: 'A2A and AgentVault' },
   { slug: 'structured-outputs-not-enough', label: 'Structured Outputs Are Not Enough' },
   { slug: 'how-to-stop-ai-agents-leaking-private-context', label: 'Stop Agents Leaking Context' },
-  { slug: 'when-your-ai-talks-to-my-ai', label: 'When Your AI Talks to My AI' },
   { slug: 'agents-reason-together', label: 'When Agents Reason Together' },
   { slug: 'understanding-agentvault-guarantees', label: 'Understanding Guarantees' },
   { slug: 'how-coordination-contracts-work', label: 'How Contracts Work' },

--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,0 +1,113 @@
+---
+// SiteFooter.astro
+// Shared footer with internal links to all concept and article pages
+const base = import.meta.env.BASE_URL;
+
+const concepts = [
+  { slug: 'agent-to-agent-privacy', label: 'Agent-to-Agent Privacy' },
+  { slug: 'bounded-disclosure', label: 'Bounded Disclosure' },
+  { slug: 'coordination-contracts', label: 'Coordination Contracts' },
+  { slug: 'bounded-signals', label: 'Bounded Signals' },
+  { slug: 'cryptographic-receipts', label: 'Cryptographic Receipts' },
+];
+
+const articles = [
+  { slug: 'why-agent-interoperability-needs-a-privacy-layer', label: 'Why Interop Needs a Privacy Layer' },
+  { slug: 'a2a-and-agentvault', label: 'A2A and AgentVault' },
+  { slug: 'structured-outputs-not-enough', label: 'Structured Outputs Are Not Enough' },
+  { slug: 'how-to-stop-ai-agents-leaking-private-context', label: 'Stop Agents Leaking Context' },
+  { slug: 'when-your-ai-talks-to-my-ai', label: 'When Your AI Talks to My AI' },
+  { slug: 'agents-reason-together', label: 'When Agents Reason Together' },
+  { slug: 'understanding-agentvault-guarantees', label: 'Understanding Guarantees' },
+  { slug: 'how-coordination-contracts-work', label: 'How Contracts Work' },
+  { slug: 'guardian-policy-defense-in-depth', label: 'Guardian Policy' },
+  { slug: 'how-receipt-verification-works', label: 'Receipt Verification' },
+  { slug: 'integrating-agentvault', label: 'Integration Guide' },
+];
+---
+
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-nav">
+      <div class="footer-nav__col">
+        <h3 class="footer-nav__heading font-mono">Concepts</h3>
+        <ul class="footer-nav__list">
+          {concepts.map(c => (
+            <li><a href={`${base}${c.slug}/`}>{c.label}</a></li>
+          ))}
+        </ul>
+      </div>
+      <div class="footer-nav__col">
+        <h3 class="footer-nav__heading font-mono">Articles</h3>
+        <ul class="footer-nav__list">
+          {articles.map(a => (
+            <li><a href={`${base}${a.slug}/`}>{a.label}</a></li>
+          ))}
+        </ul>
+      </div>
+      <div class="footer-nav__col">
+        <h3 class="footer-nav__heading font-mono">Project</h3>
+        <ul class="footer-nav__list">
+          <li><a href="https://github.com/vcav-io/agentvault" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+          <li><a href="https://github.com/vcav-io/agentvault/blob/main/docs/protocol-spec.md" target="_blank" rel="noopener noreferrer">Protocol Spec</a></li>
+          <li><a href="https://github.com/vcav-io/agentvault/issues" target="_blank" rel="noopener noreferrer">Issues</a></li>
+          <li><a href="mailto:contact@vcav.io">contact@vcav.io</a></li>
+        </ul>
+      </div>
+    </div>
+    <p class="footer-colophon text-dim">vcav.io</p>
+  </div>
+</footer>
+
+<style>
+  .site-footer {
+    padding: var(--space-2xl) 0;
+    border-top: 1px solid var(--color-border-subtle);
+  }
+
+  .footer-nav {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-xl);
+    margin-bottom: var(--space-xl);
+  }
+
+  .footer-nav__heading {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: var(--space-sm);
+  }
+
+  .footer-nav__list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .footer-nav__list a {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    text-decoration: none;
+    transition: color var(--duration-fast) var(--ease-out);
+  }
+
+  .footer-nav__list a:hover {
+    color: var(--color-accent);
+  }
+
+  .footer-colophon {
+    font-size: var(--text-sm);
+  }
+
+  @media (max-width: 639px) {
+    .footer-nav {
+      grid-template-columns: 1fr;
+      gap: var(--space-lg);
+    }
+  }
+</style>

--- a/src/components/sections/Concepts.astro
+++ b/src/components/sections/Concepts.astro
@@ -1,0 +1,82 @@
+---
+// Concepts.astro
+// Core concepts section — links to the five foundational concept pages
+const base = import.meta.env.BASE_URL;
+
+const concepts = [
+  { slug: 'agent-to-agent-privacy', label: 'Agent-to-Agent Privacy', brief: 'Why privacy is the missing layer in agent interoperability' },
+  { slug: 'bounded-disclosure', label: 'Bounded Disclosure', brief: 'Constraining what agents can reveal during coordination' },
+  { slug: 'coordination-contracts', label: 'Coordination Contracts', brief: 'Machine-readable agreements that govern agent sessions' },
+  { slug: 'bounded-signals', label: 'Bounded Signals', brief: 'Schema-constrained outputs instead of free-text exchange' },
+  { slug: 'cryptographic-receipts', label: 'Cryptographic Receipts', brief: 'Signed proof of what governed the coordination session' },
+];
+---
+
+<section class="section reveal" id="concepts">
+  <div class="container">
+    <div class="concepts">
+      <h2 class="concepts__title">Core Concepts</h2>
+      <div class="concepts__grid">
+        {concepts.map(c => (
+          <a href={`${base}${c.slug}/`} class="concept-card">
+            <span class="concept-card__label font-mono">{c.label}</span>
+            <span class="concept-card__brief">{c.brief}</span>
+          </a>
+        ))}
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .concepts {
+    max-width: var(--content-max);
+    margin: 0 auto;
+  }
+
+  .concepts__title {
+    margin-bottom: var(--space-lg);
+  }
+
+  .concepts__grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--space-md);
+  }
+
+  .concept-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    padding: var(--space-md);
+    background: var(--color-bg-panel);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    text-decoration: none;
+    transition: border-color var(--duration-fast) var(--ease-out),
+                transform 300ms var(--ease-out);
+  }
+
+  .concept-card:hover {
+    border-color: var(--color-accent-dim);
+    transform: translateY(-1px);
+  }
+
+  .concept-card__label {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  .concept-card__brief {
+    font-size: var(--text-xs);
+    color: var(--color-text-dim);
+    line-height: var(--leading-relaxed);
+  }
+
+  @media (max-width: 639px) {
+    .concepts__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,9 @@ import AssuranceTiers from '../components/sections/AssuranceTiers.astro';
 import Ecosystem from '../components/sections/Ecosystem.astro';
 import StatusMap from '../components/sections/StatusMap.astro';
 import FAQ from '../components/sections/FAQ.astro';
+import Concepts from '../components/sections/Concepts.astro';
 import OpenProject from '../components/sections/OpenProject.astro';
+import SiteFooter from '../components/SiteFooter.astro';
 import AVLockup from '../components/icons/AVLockup.astro';
 import VCAVLockup from '../components/icons/VCAVLockup.astro';
 ---
@@ -103,15 +105,10 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
     <Ecosystem />
     <StatusMap />
     <FAQ />
+    <Concepts />
     <OpenProject />
 
-    <footer class="site-footer">
-      <div class="container">
-        <p class="text-dim" style="font-size: var(--text-sm);">
-          vcav.io · <a href="mailto:contact@vcav.io" class="footer-link">contact@vcav.io</a>
-        </p>
-      </div>
-    </footer>
+    <SiteFooter />
   </main>
 </Layout>
 
@@ -377,18 +374,4 @@ import VCAVLockup from '../components/icons/VCAVLockup.astro';
     color: var(--color-accent-bright);
   }
 
-  .site-footer {
-    padding: var(--space-2xl) 0;
-    border-top: 1px solid var(--color-border-subtle);
-  }
-
-  .footer-link {
-    color: var(--color-text-dim);
-    text-decoration: none;
-    transition: color var(--duration-fast) var(--ease-out);
-  }
-
-  .footer-link:hover {
-    color: var(--color-accent);
-  }
 </style>


### PR DESCRIPTION
## Summary

- Concept and article pages were orphaned — only reachable via sidebar nav on other concept pages
- Adds a **Core Concepts** section to the homepage (5 concept cards with briefs, between FAQ and Open Project)
- Adds a shared **SiteFooter** component with three columns: Concepts (5), Articles (11), Project links
- Replaces the minimal inline footer on both the homepage and ConceptPage with the shared footer

## Test plan

- [ ] Homepage shows Core Concepts cards that link to the correct pages
- [ ] Footer renders on homepage with all internal + external links working
- [ ] Footer renders on concept/article pages with all links working
- [ ] Mobile: concept cards and footer columns stack to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)